### PR TITLE
Show encrypted values as base36 strings

### DIFF
--- a/src/status/AcceptedVotes.tsx
+++ b/src/status/AcceptedVotes.tsx
@@ -2,7 +2,7 @@ import ms from 'ms'
 import { useRouter } from 'next/router'
 import useSWR from 'swr'
 
-import { Cipher_Text } from '../crypto/types'
+import { Big, Cipher_Text, big } from '../crypto/types'
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
@@ -37,5 +37,9 @@ export const AcceptedVotes = (): JSX.Element => {
 }
 
 export function stringifyEncryptedVote(vote: Vote) {
-  return `{ auth: '${vote.auth}', tracking: { encrypted: '${vote.tracking.encrypted}', unlock: '${vote.tracking.unlock}' }, vote: { encrypted: '${vote.vote.encrypted}', unlock: '${vote.vote.unlock}' } }`
+  return `{ auth: '${vote.auth}', tracking: { encrypted: '${big(vote.tracking.encrypted).toString(36)}', unlock: '${big(
+    vote.tracking.unlock,
+  ).toString(36)}' }, vote: { encrypted: '${big(vote.vote.encrypted).toString(36)}', unlock: '${big(
+    vote.vote.unlock,
+  ).toString(36)}' } }`
 }


### PR DESCRIPTION
Testing showing these encrypted strings as more compact base 36 representation

Decimal on the left, base36 on the right.

![image](https://user-images.githubusercontent.com/6340841/97771514-c7226b80-1afa-11eb-8c15-f88fc214d7d2.png)
