### PR TITLE
[DRAFT] Add lint rule to warn about unused exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:typescript-sort-keys/recommended',
+    'plugin:import/typescript',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -19,10 +20,11 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['react', '@typescript-eslint', 'typescript-sort-keys', 'sort-destructure-keys', 'sort-keys-fix'],
+  plugins: ['react', '@typescript-eslint', 'typescript-sort-keys', 'sort-destructure-keys', 'sort-keys-fix', 'import'],
   rules: {
     '@typescript-eslint/explicit-module-boundary-types': 0, // Verbose
     '@typescript-eslint/no-empty-function': 0, // unnecessary
+    'import/no-unused-modules': [1, { unusedExports: true }], // Warn about dead code noise
     'react/jsx-sort-props': [2, { callbacksLast: true, shorthandFirst: true }], // style
     'react/react-in-jsx-scope': 0, // Handled by Next.js
     'sort-destructure-keys/sort-destructure-keys': 2, // style

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint": "^8",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-cypress": "^2.12.1",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.20.1",
     "eslint-plugin-sort-destructure-keys": "^1.3.5",
     "eslint-plugin-sort-keys-fix": "^1.1.1",


### PR DESCRIPTION
Work in progress towards automatically detecting any exports that are never being imported, aka dead code.

This would be useful, but:
- [ ] is currently is generating ~150 false positives, many look like default exports which *are* magically being used by Next.js.