### PR TITLE
Ability to disable shuffle proofs during trustee decryption

### DIFF
--- a/db-data/2024-07-18-duplicate-election.ts
+++ b/db-data/2024-07-18-duplicate-election.ts
@@ -27,17 +27,23 @@ async function copySubcollection(
   const sourceSubcollection = sourceDoc.collection(subcollectionName)
   const targetSubcollection = targetDoc.collection(subcollectionName)
 
-  const snapshot = await sourceSubcollection.get()
-  const docs = snapshot.docs
-  const amount = docs.length
+  const { docs } = await sourceSubcollection.get()
   let progress = 0
-  const intervalToReport = 20
 
-  for (const doc of docs) {
-    await targetSubcollection.doc(doc.id).set(doc.data())
-    progress++
-    if (progress % intervalToReport === 0)
-      console.log(`${subcollectionName}: ${progress}/${amount} - ${((progress / amount) * 100).toFixed(0)}%`)
+  // Use firestore batched writes
+  const batchLimit = 500 // max operations per batch
+  for (let i = 0; i < docs.length; i += batchLimit) {
+    const batch: FirebaseFirestore.WriteBatch = sourceDoc.firestore.batch()
+
+    const batchDocs = docs.slice(i, i + batchLimit)
+    for (const doc of batchDocs) {
+      batch.set(targetSubcollection.doc(doc.id), doc.data())
+    }
+
+    await batch.commit()
+    progress += batchDocs.length
+
+    console.log(`${subcollectionName}: ${progress}/${docs.length} - ${((progress / docs.length) * 100).toFixed(0)}%`)
   }
 
   console.log('Finished copy: ' + subcollectionName)

--- a/db-data/2024-07-18-duplicate-election.ts
+++ b/db-data/2024-07-18-duplicate-election.ts
@@ -13,7 +13,7 @@ import { pick } from 'lodash'
 import { firebase } from '../pages/api/_services'
 
 const election_id_from = '1721122924218'
-const election_id_to = '1721314324882'
+const election_id_to = '1722034716600'
 
 async function copySubcollection(
   sourceDoc: FirebaseFirestore.DocumentReference,

--- a/db-data/2024-07-18-duplicate-election.ts
+++ b/db-data/2024-07-18-duplicate-election.ts
@@ -2,7 +2,7 @@
 // - current 136 encrypted votes (in `votes-pending` collection)
 // - current trustees list
 
-// Other items we needed to copy over:
+// TODO: Other items we still needed to copy over:
 // - election.threshold_public_key -> for shuffle
 // - election.ballot_design -> for shuffle
 // - other trustees, in their local storage, need to copy their private keys to the new election_id

--- a/db-data/2024-07-18-duplicate-election.ts
+++ b/db-data/2024-07-18-duplicate-election.ts
@@ -8,6 +8,7 @@
 // - other trustees, in their local storage, need to copy their private keys to the new election_id
 //    - which involves both renaming the localStorage key, AND updating the value election_id inside the json blob, 2nd item.
 // - num_votes (not strictly necessary but led to some graphical glitches)
+// election.t > needed for admin to know when to decrypt
 
 import './_env'
 

--- a/db-data/2024-07-18-duplicate-election.ts
+++ b/db-data/2024-07-18-duplicate-election.ts
@@ -2,6 +2,13 @@
 // - current 136 encrypted votes (in `votes-pending` collection)
 // - current trustees list
 
+// Other items we needed to copy over:
+// - election.threshold_public_key -> for shuffle
+// - election.ballot_design -> for shuffle
+// - other trustees, in their local storage, need to copy their private keys to the new election_id
+//    - which involves both renaming the localStorage key, AND updating the value election_id inside the json blob, 2nd item.
+// - num_votes (not strictly necessary but led to some graphical glitches)
+
 import './_env'
 
 import { firebase } from '../pages/api/_services'

--- a/db-data/2024-07-18-manually-approve-pending.ts
+++ b/db-data/2024-07-18-manually-approve-pending.ts
@@ -5,7 +5,7 @@ import './_env'
 
 import { firebase } from '../pages/api/_services'
 
-const election_id = '1721314324882' // NAP Day 1 Results, All Submitted Votes
+const election_id = '1722029077573' // New Democrat Primary, Subset of Votes with Valid & Unique Passport_Proof
 
 async function renameSubcollection(
   parentDoc: FirebaseFirestore.DocumentReference,

--- a/db-data/2024-07-18-manually-approve-pending.ts
+++ b/db-data/2024-07-18-manually-approve-pending.ts
@@ -5,7 +5,7 @@ import './_env'
 
 import { firebase } from '../pages/api/_services'
 
-const election_id = '1722029077573' // New Democrat Primary, Subset of Votes with Valid & Unique Passport_Proof
+const election_id = '1722034716600' // NDP, Final, All 230 Votes
 
 async function renameSubcollection(
   parentDoc: FirebaseFirestore.DocumentReference,

--- a/db-data/2024-07-26-duplicate-election-subset.ts
+++ b/db-data/2024-07-26-duplicate-election-subset.ts
@@ -13,7 +13,7 @@ import { pick } from 'lodash'
 import { firebase } from '../pages/api/_services'
 
 const election_id_from = '1721122924218'
-const election_id_to = '1721314324882'
+const election_id_to = '1722029077573'
 
 async function copySubcollection(
   sourceDoc: FirebaseFirestore.DocumentReference,
@@ -34,11 +34,13 @@ async function copySubcollection(
 
     const batchDocs = docs.slice(i, i + batchLimit)
     for (const doc of batchDocs) {
+      if (doc.id === '79168f4563') console.log('Found doc 79168f4563!') // where did this 1 of 26 go?
+      if (subcollectionName === 'votes-pending' && !subset_to_keep.includes(doc.id)) continue // skip votes not in has_good_passport_auth subset
       batch.set(targetSubcollection.doc(doc.id), doc.data())
+      progress++
     }
 
     await batch.commit()
-    progress += batchDocs.length
 
     console.log(`${subcollectionName}: ${progress}/${docs.length} - ${((progress / docs.length) * 100).toFixed(0)}%`)
   }
@@ -89,3 +91,33 @@ export function cloneTrusteeDetails(from_election_id, to_election_id) {
 
   if (!matches) return console.warn('No localStorage matches for from_election_id: ' + from_election_id)
 }
+
+// Just the subset of votes we verified have a good passport proof
+const subset_to_keep = [
+  '13ec850164',
+  '159b08430a',
+  '15ba012b15',
+  '1669afb3d7',
+  '18fa92d241',
+  '1b73c6418b',
+  '1be44cfdb4',
+  '1fd1cb693a',
+  '1fff356f52',
+  '20b8a9fa94',
+  '235fccb4ee',
+  '251abba6e5',
+  '27302f85e9',
+  '2a8248e0d8',
+  '2ad0de9383',
+  '2d49c20201',
+  '6758f7a2db',
+  '71313c9066',
+  '79168f4563',
+  '8de58d0228',
+  '91cba5ab38',
+  '9d8190bd08',
+  'a529c9cc2b',
+  'a28873bdc4',
+  'a5285a0ee8',
+  'b16dfae0b1',
+]

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "prettier-plugin-import-sort": "^0.0.4",
     "prettier-plugin-packagejson": "^2.2.5",
     "tailwindcss": "^3.3.1",
-    "typescript": "5.4"
+    "typescript": "5.5"
   },
   "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72",
   "importSort": {

--- a/pages/api/election/[election_id]/admin/is-unlock-blocked.ts
+++ b/pages/api/election/[election_id]/admin/is-unlock-blocked.ts
@@ -18,6 +18,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   // Begin preloading all these docs
   const loadTrustees = election.collection('trustees').orderBy('index', 'asc').get()
+  const loadTrusteePartials = Promise.all(
+    (await loadTrustees).docs.map(async (doc) =>
+      (await doc.ref.collection('post-election-data').doc('partials').get()).data(),
+    ),
+  )
 
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
@@ -52,16 +57,17 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     }
     return !waiting_on // Break out of loop when we find one
   })
-  if (waiting_on) return res.status(206).send(waiting_on)
+  if (waiting_on)
+    return res.status(206).send(waiting_on)
 
-  // Check if any trustees haven't decrypted
-  trustees.every(({ email, partials }, index) => {
+    // Check if any trustees haven't decrypted
+  ;(await loadTrusteePartials).every((data, index) => {
     // Skip admin
     if (index === 0) return true
 
-    const num_decrypted = (partials || {})[first_col]?.length || 0
+    const num_decrypted = (data?.partials || {})[first_col]?.length || 0
     if (num_decrypted < num_admin_shuffled) {
-      waiting_on = email
+      waiting_on = trustees[index].email
     }
     return !waiting_on // Break out of loop when we find one
   })

--- a/pages/api/election/[election_id]/admin/unlock.ts
+++ b/pages/api/election/[election_id]/admin/unlock.ts
@@ -153,6 +153,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       ).toFixed(2)} ms/ciphertext)`,
     )
   } else {
+    console.log('starting admin shuffle')
     // Then admin does a SIV shuffle (permute + re-encryption) for each item's list
     const shuffled = await bluebird.props(
       mapValues(split, async (list) =>
@@ -166,7 +167,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     )
 
     // Store admins shuffled lists
+    console.log("starting to write admin's shuffle to db\n\n\n\n\n")
     await adminDoc.update({ preshuffled: split, shuffled })
+    console.log("succeeded to write admin's shuffle.")
     try {
       await pusher.trigger(`keygen-${election_id}`, 'update', {
         'admin@secureintervoting.org': { shuffled: shuffled.length },

--- a/pages/api/election/[election_id]/admin/unlock.ts
+++ b/pages/api/election/[election_id]/admin/unlock.ts
@@ -174,7 +174,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Store admins shuffled lists
     console.log("starting to write admin's shuffle to db\n\n\n\n\n")
-    await Promise.all([electionDoc.update({ skip_shuffle_proofs }), adminDoc.update({ preshuffled: split, shuffled })])
+    await Promise.all([
+      electionDoc.update({ skip_shuffle_proofs: !!skip_shuffle_proofs }),
+      adminDoc.update({ preshuffled: split, shuffled }),
+    ])
     console.log("succeeded to write admin's shuffle.")
     try {
       await pusher.trigger(`keygen-${election_id}`, 'update', {

--- a/pages/api/election/[election_id]/info.ts
+++ b/pages/api/election/[election_id]/info.ts
@@ -13,6 +13,7 @@ export type ElectionInfo = {
   last_decrypted_at?: Date
   observers?: string[]
   p?: string
+  skip_shuffle_proofs?: boolean
   submission_confirmation?: string
   threshold_public_key?: string
   voter_applications_allowed?: boolean

--- a/pages/api/election/[election_id]/trustees/update-admin.ts
+++ b/pages/api/election/[election_id]/trustees/update-admin.ts
@@ -88,7 +88,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       )
 
       // Store partials
-      await adminDoc.collection('post-election-data').doc('partials').set(partials, { merge: true })
+      await adminDoc.collection('post-election-data').doc('partials').set({ partials }, { merge: true })
       // console.log('Updated admin partials:', partials)
       console.log('Updated admin partials')
 

--- a/pages/api/election/[election_id]/trustees/update-admin.ts
+++ b/pages/api/election/[election_id]/trustees/update-admin.ts
@@ -29,11 +29,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   // Begin preloading these docs
   const adminDoc = electionDoc.collection('trustees').doc(ADMIN_EMAIL)
-  const adminPartials = adminDoc.collection('partials').doc('partials').get()
+  const adminPartials = adminDoc.collection('post-election-data').doc('partials').get()
   const trusteesDocs = (await electionDoc.collection('trustees').orderBy('index').get()).docs
   const trustees = trusteesDocs.map((doc) => ({ ...doc.data() }))
   const loadTrusteePartials = trusteesDocs.map(async (doc) =>
-    (await doc.ref.collection('partials').doc('partials').get()).data(),
+    (await doc.ref.collection('post-election-data').doc('partials').get()).data(),
   )
 
   // Is election_id in DB?
@@ -88,7 +88,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       )
 
       // Store partials
-      await adminDoc.collection('partials').doc('partials').set(partials, { merge: true })
+      await adminDoc.collection('post-election-data').doc('partials').set(partials, { merge: true })
       // console.log('Updated admin partials:', partials)
       console.log('Updated admin partials')
 

--- a/pages/api/election/[election_id]/trustees/update-admin.ts
+++ b/pages/api/election/[election_id]/trustees/update-admin.ts
@@ -1,0 +1,163 @@
+import { firebase } from 'api/_services'
+import { pusher } from 'api/pusher'
+import bluebird from 'bluebird'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { RP, pointToString } from 'src/crypto/curve'
+import { destringifyPartial, stringifyPartial } from 'src/crypto/stringify-partials'
+import {
+  combine_partials,
+  compute_g_to_keyshare,
+  generate_partial_decryption_proof,
+  partial_decrypt,
+  unlock_message_with_shared_secret,
+  verify_partial_decryption_proof,
+} from 'src/crypto/threshold-keygen'
+import { Partial, Shuffled, State } from 'src/trustee/trustee-state'
+import { mapValues } from 'src/utils'
+
+import { recombine_decrypteds } from '../admin/unlock'
+
+const { ADMIN_EMAIL } = process.env
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  if (!ADMIN_EMAIL) return res.status(501).send('Missing process.env.ADMIN_EMAIL')
+
+  const { election_id } = req.query
+  if (typeof election_id !== 'string') return res.status(400).send('Malformed election_id')
+
+  const electionDoc = firebase.firestore().collection('elections').doc(election_id)
+
+  // Begin preloading these docs
+  const adminDoc = electionDoc.collection('trustees').doc(ADMIN_EMAIL)
+  const trustees = (await electionDoc.collection('trustees').orderBy('index').get()).docs.map((doc) => ({
+    ...doc.data(),
+  }))
+
+  // Is election_id in DB?
+  const election = await electionDoc.get()
+  if (!election.exists) return res.status(400).send('Unknown Election ID.')
+
+  const promises: Promise<unknown>[] = []
+
+  // Get admin's private data
+  const admin = trustees[0] as Required<State> & { decryption_key: string }
+  const { private_keyshare } = admin
+
+  // Get election parameters
+  const parameters = { ...election.data() }
+
+  // If all have now shuffled, admin can partially decrypt
+  const have_all_shuffled = trustees.every((trustee) => 'shuffled' in trustee)
+  // But only if admin didn't already upload partials
+  if (have_all_shuffled && !('partials' in admin)) {
+    // Confirm that every column's shuffle proof is valid
+    const { shuffled } = trustees[parameters.t - 1]
+
+    // const checks = await bluebird.map(Object.keys(shuffled), (column) => {
+    const checks = await bluebird.map(Object.keys(shuffled), () => {
+      return true
+      // const { shuffled: prevShuffle } = destringifyShuffle(trustees[trustee.index - 1].shuffled[column])
+      // const { proof, shuffled: currShuffle } = destringifyShuffle(shuffled[column])
+
+      // return verify_shuffle_proof(rename_to_c1_and_2(prevShuffle), rename_to_c1_and_2(currShuffle), proof)
+    })
+
+    if (!checks.length || !checks.every((x) => x)) {
+      console.log("Final shuffle proof didn't fully pass")
+    } else {
+      console.log('Beginning to generate partials')
+
+      // Partially decrypt each item in every list
+      const partials = await bluebird.reduce(
+        Object.keys(shuffled),
+        (acc: Record<string, Partial[]>, column) =>
+          bluebird.props({
+            ...acc,
+            [column]: bluebird.map((shuffled as Shuffled)[column].shuffled, async ({ lock }) => ({
+              partial: partial_decrypt(RP.fromHex(lock), BigInt(private_keyshare)).toHex(),
+              proof: stringifyPartial(
+                await generate_partial_decryption_proof(RP.fromHex(lock), BigInt(private_keyshare)),
+              ),
+            })),
+          }),
+        {},
+      )
+
+      // Store partials
+      await adminDoc.update({ partials })
+      console.log('Updated admin partials:', partials)
+
+      // Notify all participants there's been an update
+      promises.push(pusher.trigger(`keygen-${election_id}`, 'update', { [ADMIN_EMAIL]: { partials: partials.length } }))
+    }
+  }
+
+  // If all have provided partials, admin can now combine partials
+  const all_have_partials = trustees.every((trustee) => 'partials' in trustee)
+  if (all_have_partials) {
+    // Have all trustees now uploaded partials for the last shuffled list?
+    const last_shuffled = trustees[trustees.length - 1].shuffled as Shuffled
+    const columns = Object.keys(last_shuffled)
+    const last_shuffled_length = last_shuffled[columns[0]].shuffled.length
+
+    if (trustees.every((t) => t.partials && t.partials[columns[0]].length >= last_shuffled_length)) {
+      // Verify that all partials have passing ZK Proofs
+      const all_broadcasts = trustees.map(({ commitments }) => commitments.map(RP.fromHex))
+      const last_trustees_shuffled = trustees[trustees.length - 1].shuffled
+      let any_failed = false
+      // For all trustees...
+      await bluebird.map(trustees, ({ partials }, index) => {
+        const g_to_trustees_keyshare = compute_g_to_keyshare(index + 1, all_broadcasts)
+        // For all columns...
+        return bluebird.map(
+          Object.keys(partials),
+          // For all votes
+          (column) =>
+            bluebird.map(partials[column], async ({ partial, proof }: Partial, voteIndex) => {
+              const result = await verify_partial_decryption_proof(
+                RP.fromHex(last_trustees_shuffled[column].shuffled[voteIndex].lock),
+                g_to_trustees_keyshare,
+                RP.fromHex(partial),
+                destringifyPartial(proof),
+              )
+              if (!result) any_failed = true
+            }),
+        )
+      })
+      if (any_failed) {
+        console.log('⚠️  Not all Partial proofs passed, refusing to combine')
+      } else {
+        // Ok, now ready to combine partials and finish decryption...
+
+        // For each column
+        const decrypted_and_split = mapValues(last_shuffled, (list, key) => {
+          // For each row
+          return (list as { shuffled: { encrypted: string }[] }).shuffled.map(({ encrypted }, index) => {
+            // 1. First we combine the partials to get the ElGamal shared secret
+            const partials = trustees.map((t) => RP.fromHex(t.partials[key][index].partial))
+            const shared_secret = combine_partials(partials)
+
+            // 2. Then we can unlock each messages
+            const unlocked = unlock_message_with_shared_secret(shared_secret, RP.fromHex(encrypted))
+            return pointToString(unlocked)
+          })
+        }) as Record<string, string[]>
+
+        // 3. Finally we recombine the separated columns back together via tracking numbers
+        const decrypteds_by_tracking = recombine_decrypteds(decrypted_and_split)
+
+        // Store decrypteds as an array
+        const decrypted = Object.values(decrypteds_by_tracking)
+        // 4. And save the results to election.decrypted
+        await electionDoc.update({ decrypted, last_decrypted_at: new Date() })
+        // And notify everyone we have new decrypted
+        await pusher.trigger(election_id, 'decrypted', '')
+      }
+    }
+  }
+
+  // Wait for all pending promises to finish
+  await Promise.all(promises)
+
+  return res.status(201).send(`Updated admin object`)
+}

--- a/pages/api/election/[election_id]/trustees/update-admin.ts
+++ b/pages/api/election/[election_id]/trustees/update-admin.ts
@@ -100,7 +100,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   // If all have provided partials, admin can now combine partials
   const trusteePartials = await Promise.all(loadTrusteePartials)
   // console.log({ trusteePartials })
-  const all_have_partials = trusteePartials.every((t) => !!t)
+  type TrusteeWithPartial = { partials: { [col: string]: Partial[] } }
+  const hasPartial = (trustee: FirebaseFirestore.DocumentData | undefined): trustee is TrusteeWithPartial =>
+    !!trustee?.partials
+
+  const all_have_partials = trusteePartials.every(hasPartial)
   console.log({ all_have_partials })
 
   if (all_have_partials) {

--- a/pages/api/election/[election_id]/trustees/update.ts
+++ b/pages/api/election/[election_id]/trustees/update.ts
@@ -1,4 +1,3 @@
-import { allowCors } from 'api/_cors'
 import { sumBy } from 'lodash-es'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { RP, random_bigint } from 'src/crypto/curve'
@@ -20,7 +19,7 @@ import updateAdmin from './update-admin'
 
 const { ADMIN_EMAIL } = process.env
 
-export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
+export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (!ADMIN_EMAIL) return res.status(501).send('Missing process.env.ADMIN_EMAIL')
 
   const { election_id } = req.query
@@ -193,7 +192,7 @@ export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
   await Promise.all(promises)
 
   return res.status(201).send(`Updated ${email} object`)
-})
+}
 
 /** Call another endpoint, printing its response to the console */
 const mockNextResponse = {

--- a/pages/api/election/[election_id]/trustees/update.ts
+++ b/pages/api/election/[election_id]/trustees/update.ts
@@ -61,7 +61,12 @@ export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
   const commafied = transform_email_keys(body, 'commafy')
 
   // Save whatever other new data they gave us
-  await trusteeDoc.update(commafied)
+  // Except partial goes into its own sub-doc
+  if (body.partials) {
+    await trusteeDoc.collection('post-election-data').doc('partials').set(commafied)
+  } else {
+    await trusteeDoc.update(commafied)
+  }
   console.log('Saved update to', email, commafied)
 
   const promises: Promise<unknown>[] = []
@@ -187,7 +192,7 @@ export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
   // Wait for all pending promises to finish
   await Promise.all(promises)
 
-  res.status(201).send(`Updated ${email} object`)
+  return res.status(201).send(`Updated ${email} object`)
 })
 
 /** Call another endpoint, printing its response to the console */

--- a/pages/api/election/[election_id]/trustees/update.ts
+++ b/pages/api/election/[election_id]/trustees/update.ts
@@ -1,3 +1,4 @@
+import { allowCors } from 'api/_cors'
 import bluebird from 'bluebird'
 import { sumBy } from 'lodash-es'
 import { NextApiRequest, NextApiResponse } from 'next'
@@ -30,7 +31,7 @@ import { commafy, transform_email_keys } from './commafy'
 
 const { ADMIN_EMAIL } = process.env
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
   if (!ADMIN_EMAIL) return res.status(501).send('Missing process.env.ADMIN_EMAIL')
 
   const { election_id } = req.query
@@ -315,4 +316,4 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   await Promise.all(promises)
 
   res.status(201).send(`Updated ${email} object`)
-}
+})

--- a/pages/api/election/[election_id]/trustees/update.ts
+++ b/pages/api/election/[election_id]/trustees/update.ts
@@ -1,39 +1,24 @@
 import { allowCors } from 'api/_cors'
-import bluebird from 'bluebird'
 import { sumBy } from 'lodash-es'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { RP, pointToString, random_bigint } from 'src/crypto/curve'
+import { RP, random_bigint } from 'src/crypto/curve'
 import { keygenDecrypt, keygenEncrypt } from 'src/crypto/keygen-encrypt'
-// import { rename_to_c1_and_2 } from 'src/crypto/shuffle'
-// import { verify_shuffle_proof } from 'src/crypto/shuffle-proof'
-import { destringifyPartial, stringifyPartial } from 'src/crypto/stringify-partials'
-// import { destringifyShuffle } from 'src/crypto/stringify-shuffle'
 import {
-  combine_partials,
-  compute_g_to_keyshare,
   compute_keyshare,
   compute_pub_key,
   evaluate_private_polynomial,
-  generate_partial_decryption_proof,
   is_received_share_valid,
   partial_decrypt,
-  unlock_message_with_shared_secret,
-  verify_partial_decryption_proof,
 } from 'src/crypto/threshold-keygen'
 import { randomizer } from 'src/trustee/keygen/11-PartialDecryptionTest'
-import { Partial, Shuffled, State, Trustee } from 'src/trustee/trustee-state'
-import { mapValues } from 'src/utils'
+import { State, Trustee } from 'src/trustee/trustee-state'
 
 import { firebase } from '../../../_services'
 import { pusher } from '../../../pusher'
-import { recombine_decrypteds } from '../admin/unlock'
 import { commafy, transform_email_keys } from './commafy'
+import updateAdmin from './update-admin'
 
 const { ADMIN_EMAIL } = process.env
-
-// TODO: we now have ./update-admin endpoint, that handles all the followup steps by admin.
-// - Only for unlock for now, not DKG.
-// Cleaner to remove those code paths from this one, and just have this script call that instead?
 
 export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
   if (!ADMIN_EMAIL) return res.status(501).send('Missing process.env.ADMIN_EMAIL')
@@ -86,12 +71,10 @@ export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
 
   // If they provided their public key, admin can now encrypt pairwise shares for them.
   // If they provided encrypted shares, admin can decrypt their own and verify them.
-  // If they provided the final shuffled votes, admin can partially decrypt
-  // If they provided the final partial, admin can combine partials
-  if (body.recipient_key || body.encrypted_pairwise_shares_for || body.shuffled || body.partials) {
+  if (body.recipient_key || body.encrypted_pairwise_shares_for) {
     // Get admin's private data
     const admin = { ...(await loadAdmin).data() } as Required<State> & { decryption_key: string }
-    const { decryption_key, private_coefficients, private_keyshare } = admin
+    const { decryption_key, private_coefficients } = admin
 
     // Get election parameters
     const parameters = { ...election.data() }
@@ -195,129 +178,22 @@ export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
       // Notify all participants there's been an update
       promises.push(pusher.trigger(`keygen-${election_id}`, 'update', { [ADMIN_EMAIL]: { partial_decryption } }))
     }
-
-    // Logic for final shuffled votes
-    if (body.shuffled) {
-      // If this is the last trustee, we can begin partially decrypting
-      if (trustee.index === parameters.t - 1) {
-        const { shuffled } = body
-
-        // const trustees = (await electionDoc.collection('trustees').orderBy('index').get()).docs.map((doc) => ({
-        //   ...doc.data(),
-        // }))
-
-        // Confirm that every column's shuffle proof is valid
-        // const checks = await bluebird.map(Object.keys(shuffled), (column) => {
-        const checks = await bluebird.map(Object.keys(shuffled), () => {
-          return true
-          // const { shuffled: prevShuffle } = destringifyShuffle(trustees[trustee.index - 1].shuffled[column])
-          // const { proof, shuffled: currShuffle } = destringifyShuffle(shuffled[column])
-
-          // return verify_shuffle_proof(rename_to_c1_and_2(prevShuffle), rename_to_c1_and_2(currShuffle), proof)
-        })
-
-        if (!checks.length || !checks.every((x) => x)) {
-          console.log("Final shuffle proof didn't fully pass")
-        } else {
-          // Partially decrypt each item in every list
-          const partials = await bluebird.reduce(
-            Object.keys(shuffled),
-            (acc: Record<string, Partial[]>, column) =>
-              bluebird.props({
-                ...acc,
-                [column]: bluebird.map((shuffled as Shuffled)[column].shuffled, async ({ lock }) => ({
-                  partial: partial_decrypt(RP.fromHex(lock), BigInt(private_keyshare)).toHex(),
-                  proof: stringifyPartial(
-                    await generate_partial_decryption_proof(RP.fromHex(lock), BigInt(private_keyshare)),
-                  ),
-                })),
-              }),
-            {},
-          )
-
-          // Store partials
-          await adminDoc.update({ partials })
-          console.log('Updated admin partials:', partials)
-
-          // Notify all participants there's been an update
-          promises.push(
-            pusher.trigger(`keygen-${election_id}`, 'update', { [ADMIN_EMAIL]: { partials: partials.length } }),
-          )
-        }
-      }
-    }
-
-    // Logic for final partial
-    if (body.partials) {
-      // Get all trustees
-      const trustees = (await electionDoc.collection('trustees').orderBy('index').get()).docs.map((doc) => ({
-        ...doc.data(),
-      }))
-
-      // Have all trustees now uploaded partials for the last shuffled list?
-      const last_shuffled = trustees[trustees.length - 1].shuffled as Shuffled
-      const columns = Object.keys(last_shuffled)
-      const last_shuffled_length = last_shuffled[columns[0]].shuffled.length
-
-      if (trustees.every((t) => t.partials && t.partials[columns[0]].length >= last_shuffled_length)) {
-        // Verify that all partials have passing ZK Proofs
-        const all_broadcasts = trustees.map(({ commitments }) => commitments.map(RP.fromHex))
-        const last_trustees_shuffled = trustees[trustees.length - 1].shuffled
-        let any_failed = false
-        // For all trustees...
-        await bluebird.map(trustees, ({ partials }, index) => {
-          const g_to_trustees_keyshare = compute_g_to_keyshare(index + 1, all_broadcasts)
-          // For all columns...
-          return bluebird.map(
-            Object.keys(partials),
-            // For all votes
-            (column) =>
-              bluebird.map(partials[column], async ({ partial, proof }: Partial, voteIndex) => {
-                const result = await verify_partial_decryption_proof(
-                  RP.fromHex(last_trustees_shuffled[column].shuffled[voteIndex].lock),
-                  g_to_trustees_keyshare,
-                  RP.fromHex(partial),
-                  destringifyPartial(proof),
-                )
-                if (!result) any_failed = true
-              }),
-          )
-        })
-        if (any_failed) {
-          console.log('⚠️  Not all Partial proofs passed, refusing to combine')
-        } else {
-          // Ok, now ready to combine partials and finish decryption...
-
-          // For each column
-          const decrypted_and_split = mapValues(last_shuffled, (list, key) => {
-            // For each row
-            return (list as { shuffled: { encrypted: string }[] }).shuffled.map(({ encrypted }, index) => {
-              // 1. First we combine the partials to get the ElGamal shared secret
-              const partials = trustees.map((t) => RP.fromHex(t.partials[key][index].partial))
-              const shared_secret = combine_partials(partials)
-
-              // 2. Then we can unlock each messages
-              const unlocked = unlock_message_with_shared_secret(shared_secret, RP.fromHex(encrypted))
-              return pointToString(unlocked)
-            })
-          }) as Record<string, string[]>
-
-          // 3. Finally we recombine the separated columns back together via tracking numbers
-          const decrypteds_by_tracking = recombine_decrypteds(decrypted_and_split)
-
-          // Store decrypteds as an array
-          const decrypted = Object.values(decrypteds_by_tracking)
-          // 4. And save the results to election.decrypted
-          await electionDoc.update({ decrypted, last_decrypted_at: new Date() })
-          // And notify everyone we have new decrypted
-          await pusher.trigger(election_id, 'decrypted', '')
-        }
-      }
-    }
   }
+
+  // If they provided the final shuffled votes, admin can partially decrypt
+  // If they provided the final partial, admin can combine partials
+  if (body.shuffled || body.partials) await updateAdmin(req, mockNextResponse)
 
   // Wait for all pending promises to finish
   await Promise.all(promises)
 
   res.status(201).send(`Updated ${email} object`)
 })
+
+/** Call another endpoint, printing its response to the console */
+const mockNextResponse = {
+  status: (status: number) => {
+    const print = (message: unknown) => console.log(`${status}: ${message}`)
+    return { json: print, send: print }
+  },
+} as unknown as NextApiResponse

--- a/pages/api/election/[election_id]/trustees/update.ts
+++ b/pages/api/election/[election_id]/trustees/update.ts
@@ -3,10 +3,10 @@ import { sumBy } from 'lodash-es'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { RP, pointToString, random_bigint } from 'src/crypto/curve'
 import { keygenDecrypt, keygenEncrypt } from 'src/crypto/keygen-encrypt'
-import { rename_to_c1_and_2 } from 'src/crypto/shuffle'
-import { verify_shuffle_proof } from 'src/crypto/shuffle-proof'
+// import { rename_to_c1_and_2 } from 'src/crypto/shuffle'
+// import { verify_shuffle_proof } from 'src/crypto/shuffle-proof'
 import { destringifyPartial, stringifyPartial } from 'src/crypto/stringify-partials'
-import { destringifyShuffle } from 'src/crypto/stringify-shuffle'
+// import { destringifyShuffle } from 'src/crypto/stringify-shuffle'
 import {
   combine_partials,
   compute_g_to_keyshare,
@@ -197,16 +197,18 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       if (trustee.index === parameters.t - 1) {
         const { shuffled } = body
 
-        const trustees = (await electionDoc.collection('trustees').orderBy('index').get()).docs.map((doc) => ({
-          ...doc.data(),
-        }))
+        // const trustees = (await electionDoc.collection('trustees').orderBy('index').get()).docs.map((doc) => ({
+        //   ...doc.data(),
+        // }))
 
         // Confirm that every column's shuffle proof is valid
-        const checks = await bluebird.map(Object.keys(shuffled), (column) => {
-          const { shuffled: prevShuffle } = destringifyShuffle(trustees[trustee.index - 1].shuffled[column])
-          const { proof, shuffled: currShuffle } = destringifyShuffle(shuffled[column])
+        // const checks = await bluebird.map(Object.keys(shuffled), (column) => {
+        const checks = await bluebird.map(Object.keys(shuffled), () => {
+          return true
+          // const { shuffled: prevShuffle } = destringifyShuffle(trustees[trustee.index - 1].shuffled[column])
+          // const { proof, shuffled: currShuffle } = destringifyShuffle(shuffled[column])
 
-          return verify_shuffle_proof(rename_to_c1_and_2(prevShuffle), rename_to_c1_and_2(currShuffle), proof)
+          // return verify_shuffle_proof(rename_to_c1_and_2(prevShuffle), rename_to_c1_and_2(currShuffle), proof)
         })
 
         if (!checks.length || !checks.every((x) => x)) {

--- a/pages/api/election/[election_id]/trustees/update.ts
+++ b/pages/api/election/[election_id]/trustees/update.ts
@@ -31,6 +31,10 @@ import { commafy, transform_email_keys } from './commafy'
 
 const { ADMIN_EMAIL } = process.env
 
+// TODO: we now have ./update-admin endpoint, that handles all the followup steps by admin.
+// - Only for unlock for now, not DKG.
+// Cleaner to remove those code paths from this one, and just have this script call that instead?
+
 export default allowCors(async (req: NextApiRequest, res: NextApiResponse) => {
   if (!ADMIN_EMAIL) return res.status(501).send('Missing process.env.ADMIN_EMAIL')
 

--- a/src/_shared/Button.tsx
+++ b/src/_shared/Button.tsx
@@ -105,7 +105,6 @@ export const OnClickButton = forwardRef<HTMLAnchorElement, OnClickProps>(
         a:not(.disabled):hover {
           background-color: ${invertColor ? '#fff' : darkBlue};
           color: ${invertColor ? '#000' : '#fff'};
-          border-color: ${invertColor ? darkBlue : '#fff'};
           cursor: pointer;
         }
       `}</style>

--- a/src/admin/Voters/UnlockVotesButton.tsx
+++ b/src/admin/Voters/UnlockVotesButton.tsx
@@ -7,63 +7,78 @@ import { Spinner } from '../Spinner'
 import { useStored } from '../useStored'
 
 export const UnlockVotesButton = ({ num_approved, num_voted }: { num_approved: number; num_voted: number }) => {
-  const { election_id, election_title, esignature_requested } = useStored()
+  const { election_id, election_title, esignature_requested, trustees } = useStored()
+  const show_dropdown = trustees && trustees?.length > 1
   const { user } = useUser()
   const [unlocking, toggle_unlocking] = useReducer((state) => !state, false)
 
-  return (
-    <OnClickButton
-      className="bg-white"
-      disabled={!num_approved}
-      disabledExplanation={
-        !num_approved &&
-        esignature_requested &&
-        !!num_voted &&
-        "No votes with approved signatures.\n\nHover over individual signatures to Approve/Reject them, or click 'Signature' column header to Approve All."
+  async function triggerUnlock(options?: { skip_shuffle_proofs?: boolean }) {
+    const startTime = Date.now()
+    const expectedTimeout = 60
+    const expectedMilliseconds = (expectedTimeout - 1) * 1000
+
+    toggle_unlocking()
+    const response = await api(`election/${election_id}/admin/unlock`, { options }).catch(() => {})
+
+    const adminMsg = `Election title: ${election_title}\nElection ID: ${election_id}\nUser: ${user.name}\nEmail: ${user.email}\nVotes: ${num_approved}`
+
+    if (!response || response?.status !== 201) {
+      if (Date.now() - startTime > expectedMilliseconds) {
+        toggle_unlocking()
+        api('/pushover', {
+          message: adminMsg,
+          title: `Admin ${user.email} unlock timeout`,
+        })
+        alert('The backend server timed out after 60 seconds. Alert team@siv.org for manual unlock')
+        return
       }
-      style={{ alignSelf: 'baseline', margin: 0, marginLeft: 5, padding: '5px 10px' }}
-      onClick={async () => {
-        const startTime = Date.now()
-        const expectedTimeout = 60
-        const expectedMilliseconds = (expectedTimeout - 1) * 1000
 
-        toggle_unlocking()
-        const response = await api(`election/${election_id}/admin/unlock`).catch(() => {})
+      const json = await response?.json()
+      console.error('Unlocking error:', json)
 
-        const adminMsg = `Election title: ${election_title}\nElection ID: ${election_id}\nUser: ${user.name}\nEmail: ${user.email}\nVotes: ${num_approved}`
+      api('/pushover', {
+        message: `${adminMsg}\nError: ${JSON.stringify(json)}`,
+        title: `Admin ${user.email} unlock error`,
+      })
 
-        if (!response || response?.status !== 201) {
-          if (Date.now() - startTime > expectedMilliseconds) {
-            toggle_unlocking()
-            api('/pushover', {
-              message: adminMsg,
-              title: `Admin ${user.email} unlock timeout`,
-            })
-            alert('The backend server timed out after 60 seconds. Alert team@siv.org for manual unlock')
-            return
-          }
+      if (json) {
+        alert(JSON.stringify(json.error))
+      } else {
+        alert('Unknown error during unlocking')
+      }
+    }
+    toggle_unlocking()
+  }
 
-          const json = await response?.json()
-          console.error('Unlocking error:', json)
-
-          api('/pushover', {
-            message: `${adminMsg}\nError: ${JSON.stringify(json)}`,
-            title: `Admin ${user.email} unlock error`,
-          })
-
-          if (json) {
-            alert(JSON.stringify(json.error))
-          } else {
-            alert('Unknown error during unlocking')
-          }
+  return (
+    <div>
+      <OnClickButton
+        className={`bg-white !m-0 !ml-[5px] self-baseline !py-[5px] !px-2.5 ${show_dropdown && '!rounded-r-none'}`}
+        disabled={!num_approved}
+        disabledExplanation={
+          !num_approved &&
+          esignature_requested &&
+          !!num_voted &&
+          "No votes with approved signatures.\n\nHover over individual signatures to Approve/Reject them, or click 'Signature' column header to Approve All."
         }
-        toggle_unlocking()
-      }}
-    >
-      <>
-        {unlocking && <Spinner />}
-        Unlock{unlocking ? 'ing' : ''} {num_approved} Vote{num_approved === 1 ? '' : 's'}
-      </>
-    </OnClickButton>
+        onClick={triggerUnlock}
+      >
+        <>
+          {unlocking && <Spinner />}
+          Unlock{unlocking ? 'ing' : ''} {num_approved} Vote{num_approved === 1 ? '' : 's'}
+        </>
+      </OnClickButton>
+
+      {/* Dropdown arrow to skip shuffle proofs */}
+      {show_dropdown && (
+        <OnClickButton
+          className="!m-0 bg-white !rounded-l-none !border-l-0 self-baseline !py-px !px-[7px] text-[20px] relative top-0.5"
+          disabled={!num_approved}
+          onClick={() => confirm('Unlock without shuffle proofs?') && triggerUnlock({ skip_shuffle_proofs: true })}
+        >
+          ▾
+        </OnClickButton>
+      )}
+    </div>
   )
 }

--- a/src/admin/Voters/UnlockedStatus.tsx
+++ b/src/admin/Voters/UnlockedStatus.tsx
@@ -16,7 +16,13 @@ export const UnlockedStatus = () => {
   const more_to_unlock = num_voted > unlocked_votes.length
 
   return (
-    <div className={more_to_unlock || isUnlockBlocked ? 'warning' : ''}>
+    <div
+      className={`border border-solid rounded-md p-2.5 mb-3.5 ${
+        more_to_unlock || isUnlockBlocked
+          ? '!border-[rgba(175,157,0,0.66)] !bg-[rgba(237,177,27,0.07)]'
+          : 'border-[rgba(26,89,0,0.66)] bg-[rgba(0,128,0,0.07)]'
+      }`}
+    >
       {isUnlockBlocked ? (
         <p>
           ⚠️ Unlocking: Waiting on Observer <i> {isUnlockBlocked}</i>
@@ -49,20 +55,6 @@ export const UnlockedStatus = () => {
         </p>
       )}
       <style jsx>{`
-        div {
-          border: 1px solid rgba(26, 89, 0, 0.66);
-          background: rgba(0, 128, 0, 0.07);
-          border-radius: 5px;
-
-          padding: 10px;
-          margin-bottom: 15px;
-        }
-
-        div.warning {
-          border-color: rgba(175, 157, 0, 0.66);
-          background: rgba(237, 177, 27, 0.07);
-        }
-
         p {
           margin: 0;
         }

--- a/src/admin/Voters/UnlockedStatus.tsx
+++ b/src/admin/Voters/UnlockedStatus.tsx
@@ -25,7 +25,7 @@ export const UnlockedStatus = () => {
     >
       {isUnlockBlocked ? (
         <p>
-          ⚠️ Unlocking: Waiting on Observer <i> {isUnlockBlocked}</i>
+          ⚠️ Unlocking: Waiting on Observer <i className="font-medium"> {isUnlockBlocked}</i>
         </p>
       ) : !more_to_unlock ? (
         <p>
@@ -57,10 +57,6 @@ export const UnlockedStatus = () => {
       <style jsx>{`
         p {
           margin: 0;
-        }
-
-        i {
-          font-weight: 500;
         }
 
         a {

--- a/src/admin/Voters/UnlockedStatus.tsx
+++ b/src/admin/Voters/UnlockedStatus.tsx
@@ -25,7 +25,7 @@ export const UnlockedStatus = () => {
         <p>
           ✅ Successfully{' '}
           <Link href={`/election/${election_id}`}>
-            <a className="status" target="_blank">
+            <a className="!font-medium text-black" target="_blank">
               unlocked {unlocked_votes.length}
             </a>
           </Link>{' '}
@@ -74,11 +74,6 @@ export const UnlockedStatus = () => {
         a {
           font-weight: 600;
           cursor: pointer;
-        }
-
-        a.status {
-          color: black;
-          font-weight: 500;
         }
 
         b {

--- a/src/admin/Voters/UnlockedStatus.tsx
+++ b/src/admin/Voters/UnlockedStatus.tsx
@@ -31,13 +31,14 @@ export const UnlockedStatus = () => {
         <p>
           ✅ Successfully{' '}
           <Link href={`/election/${election_id}`}>
-            <a className="!font-medium text-black" target="_blank">
+            <a className="font-medium text-black cursor-pointer" target="_blank">
               unlocked {unlocked_votes.length}
             </a>
           </Link>{' '}
           votes.{' '}
           {notified_unlocked !== unlocked_votes.length ? (
             <a
+              className="font-semibold cursor-pointer"
               onClick={async () => {
                 await api(`election/${election_id}/admin/notify-unlocked`)
                 revalidate(election_id)
@@ -57,11 +58,6 @@ export const UnlockedStatus = () => {
       <style jsx>{`
         p {
           margin: 0;
-        }
-
-        a {
-          font-weight: 600;
-          cursor: pointer;
         }
       `}</style>
     </div>

--- a/src/admin/Voters/UnlockedStatus.tsx
+++ b/src/admin/Voters/UnlockedStatus.tsx
@@ -46,7 +46,7 @@ export const UnlockedStatus = () => {
               Notify voters?
             </a>
           ) : (
-            <b>Voters notified.</b>
+            <b className="font-semibold">Voters notified.</b>
           )}
         </p>
       ) : (
@@ -62,10 +62,6 @@ export const UnlockedStatus = () => {
         a {
           font-weight: 600;
           cursor: pointer;
-        }
-
-        b {
-          font-weight: 600;
         }
       `}</style>
     </div>

--- a/src/crypto/shuffle.ts
+++ b/src/crypto/shuffle.ts
@@ -59,7 +59,7 @@ async function shuffle(
   })
 
   // Can skip generating costly proof
-  if (!options?.skip_proof) return { shuffled }
+  if (options?.skip_proof) return { shuffled }
 
   // Finally we generate a ZK proof that it's a valid shuffle
   const proof = await generate_shuffle_proof(

--- a/src/crypto/shuffle.ts
+++ b/src/crypto/shuffle.ts
@@ -6,8 +6,6 @@ export type Cipher = { encrypted: RP; lock: RP }
 export type Public_Key = RP
 const G = RP.BASE
 
-export const SKIP_SHUFFLE_PROOFS = true
-
 export async function shuffleWithProof(
   pub_key: Public_Key,
   inputs: Cipher[],

--- a/src/crypto/shuffle.ts
+++ b/src/crypto/shuffle.ts
@@ -1,5 +1,5 @@
 import { RP, random_bigint } from './curve'
-import { Shuffle_Proof, generate_shuffle_proof } from './shuffle-proof'
+// import { Shuffle_Proof, generate_shuffle_proof } from './shuffle-proof'
 
 export type Cipher = { encrypted: RP; lock: RP }
 
@@ -9,7 +9,8 @@ const G = RP.BASE
 export async function shuffle(
   pub_key: Public_Key,
   inputs: Cipher[],
-): Promise<{ proof: Shuffle_Proof; shuffled: Cipher[] }> {
+  // ): Promise<{ proof: Shuffle_Proof; shuffled: Cipher[] }> {
+): Promise<{ shuffled: Cipher[] }> {
   // First, we need a permutation array and reencryption values
   const permutes = build_permutation_array(inputs.length)
 
@@ -34,15 +35,16 @@ export async function shuffle(
   })
 
   // Finally we generate a ZK proof that it's a valid shuffle
-  const proof = await generate_shuffle_proof(
-    rename_to_c1_and_2(inputs),
-    rename_to_c1_and_2(shuffled),
-    reencrypts,
-    permutes,
-    pub_key,
-  )
+  // const proof = await generate_shuffle_proof(
+  //   rename_to_c1_and_2(inputs),
+  //   rename_to_c1_and_2(shuffled),
+  //   reencrypts,
+  //   permutes,
+  //   pub_key,
+  // )
 
-  return { proof, shuffled }
+  // return { proof, shuffled }
+  return { shuffled }
 }
 
 /** Generates an array of all integers up to `size`, in a random order */

--- a/src/crypto/stringify-shuffle.ts
+++ b/src/crypto/stringify-shuffle.ts
@@ -5,61 +5,62 @@ import { RP } from './curve'
 import { shuffle } from './shuffle'
 
 export type CipherStrings = ReturnType<typeof stringifyShuffle>['shuffled'][0]
-export function stringifyShuffle({ proof, shuffled }: AsyncReturnType<typeof shuffle>) {
-  const p = proof
-  const simple = p.simple_shuffle_proof
+// export function stringifyShuffle({ proof, shuffled }: AsyncReturnType<typeof shuffle>) {
+export function stringifyShuffle({ shuffled }: AsyncReturnType<typeof shuffle>) {
+  // const p = proof
+  // const simple = p.simple_shuffle_proof
   return {
-    proof: {
-      As: p.As.map(String),
-      Cs: p.Cs.map(String),
-      Ds: p.Ds.map(String),
-      Gamma: String(p.Gamma),
-      H: String(p.H),
-      Lambda1: String(p.Lambda1),
-      Lambda2: String(p.Lambda2),
-      Us: p.Us.map(String),
-      Ws: p.Ws.map(String),
-      sigmas: p.sigmas.map(String),
-      simple_shuffle_proof: {
-        Gamma: String(simple.Gamma),
-        Thetas: simple.Thetas.map(String),
-        Xs: simple.Xs.map(String),
-        Ys: simple.Ys.map(String),
-        alphas: simple.alphas.map(String),
-      },
-      tau: String(p.tau),
-    },
+    //   proof: {
+    //     As: p.As.map(String),
+    //     Cs: p.Cs.map(String),
+    //     Ds: p.Ds.map(String),
+    //     Gamma: String(p.Gamma),
+    //     H: String(p.H),
+    //     Lambda1: String(p.Lambda1),
+    //     Lambda2: String(p.Lambda2),
+    //     Us: p.Us.map(String),
+    //     Ws: p.Ws.map(String),
+    //     sigmas: p.sigmas.map(String),
+    //     simple_shuffle_proof: {
+    //       Gamma: String(simple.Gamma),
+    //       Thetas: simple.Thetas.map(String),
+    //       Xs: simple.Xs.map(String),
+    //       Ys: simple.Ys.map(String),
+    //       alphas: simple.alphas.map(String),
+    //     },
+    //     tau: String(p.tau),
+    //   },
     shuffled: shuffled.map((r) => mapValues(r, String)),
   }
 }
 
 export function destringifyShuffle({
-  proof,
+  // proof,
   shuffled,
 }: ReturnType<typeof stringifyShuffle>): AsyncReturnType<typeof shuffle> {
-  const p = proof
-  const simple = p.simple_shuffle_proof
+  // const p = proof
+  // const simple = p.simple_shuffle_proof
   return {
-    proof: {
-      As: p.As.map(RP.fromHex),
-      Cs: p.Cs.map(RP.fromHex),
-      Ds: p.Ds.map(RP.fromHex),
-      Gamma: RP.fromHex(p.Gamma),
-      H: RP.fromHex(p.H),
-      Lambda1: RP.fromHex(p.Lambda1),
-      Lambda2: RP.fromHex(p.Lambda2),
-      Us: p.Us.map(RP.fromHex),
-      Ws: p.Ws.map(RP.fromHex),
-      sigmas: p.sigmas.map(BigInt),
-      simple_shuffle_proof: {
-        Gamma: RP.fromHex(simple.Gamma),
-        Thetas: simple.Thetas.map(RP.fromHex),
-        Xs: simple.Xs.map(RP.fromHex),
-        Ys: simple.Ys.map(RP.fromHex),
-        alphas: simple.alphas.map(BigInt),
-      },
-      tau: BigInt(p.tau),
-    },
+    // proof: {
+    //   As: p.As.map(RP.fromHex),
+    //   Cs: p.Cs.map(RP.fromHex),
+    //   Ds: p.Ds.map(RP.fromHex),
+    //   Gamma: RP.fromHex(p.Gamma),
+    //   H: RP.fromHex(p.H),
+    //   Lambda1: RP.fromHex(p.Lambda1),
+    //   Lambda2: RP.fromHex(p.Lambda2),
+    //   Us: p.Us.map(RP.fromHex),
+    //   Ws: p.Ws.map(RP.fromHex),
+    //   sigmas: p.sigmas.map(BigInt),
+    //   simple_shuffle_proof: {
+    //     Gamma: RP.fromHex(simple.Gamma),
+    //     Thetas: simple.Thetas.map(RP.fromHex),
+    //     Xs: simple.Xs.map(RP.fromHex),
+    //     Ys: simple.Ys.map(RP.fromHex),
+    //     alphas: simple.alphas.map(BigInt),
+    //   },
+    //   tau: BigInt(p.tau),
+    // },
     shuffled: shuffled.map((r) => mapValues(r, RP.fromHex)),
   }
 }

--- a/src/crypto/stringify-shuffle.ts
+++ b/src/crypto/stringify-shuffle.ts
@@ -2,65 +2,74 @@ import { mapValues } from 'lodash'
 
 import { AsyncReturnType } from './async-return-type'
 import { RP } from './curve'
-import { shuffle } from './shuffle'
+import { shuffleWithProof, shuffleWithoutProof } from './shuffle'
 
 export type CipherStrings = ReturnType<typeof stringifyShuffle>['shuffled'][0]
-// export function stringifyShuffle({ proof, shuffled }: AsyncReturnType<typeof shuffle>) {
-export function stringifyShuffle({ shuffled }: AsyncReturnType<typeof shuffle>) {
-  // const p = proof
-  // const simple = p.simple_shuffle_proof
+export function stringifyShuffle({ proof, shuffled }: AsyncReturnType<typeof shuffleWithProof>) {
+  const p = proof
+  const simple = p.simple_shuffle_proof
   return {
-    //   proof: {
-    //     As: p.As.map(String),
-    //     Cs: p.Cs.map(String),
-    //     Ds: p.Ds.map(String),
-    //     Gamma: String(p.Gamma),
-    //     H: String(p.H),
-    //     Lambda1: String(p.Lambda1),
-    //     Lambda2: String(p.Lambda2),
-    //     Us: p.Us.map(String),
-    //     Ws: p.Ws.map(String),
-    //     sigmas: p.sigmas.map(String),
-    //     simple_shuffle_proof: {
-    //       Gamma: String(simple.Gamma),
-    //       Thetas: simple.Thetas.map(String),
-    //       Xs: simple.Xs.map(String),
-    //       Ys: simple.Ys.map(String),
-    //       alphas: simple.alphas.map(String),
-    //     },
-    //     tau: String(p.tau),
-    //   },
+    proof: {
+      As: p.As.map(String),
+      Cs: p.Cs.map(String),
+      Ds: p.Ds.map(String),
+      Gamma: String(p.Gamma),
+      H: String(p.H),
+      Lambda1: String(p.Lambda1),
+      Lambda2: String(p.Lambda2),
+      Us: p.Us.map(String),
+      Ws: p.Ws.map(String),
+      sigmas: p.sigmas.map(String),
+      simple_shuffle_proof: {
+        Gamma: String(simple.Gamma),
+        Thetas: simple.Thetas.map(String),
+        Xs: simple.Xs.map(String),
+        Ys: simple.Ys.map(String),
+        alphas: simple.alphas.map(String),
+      },
+      tau: String(p.tau),
+    },
     shuffled: shuffled.map((r) => mapValues(r, String)),
   }
 }
 
+export function stringifyShuffleWithoutProof({ shuffled }: AsyncReturnType<typeof shuffleWithoutProof>) {
+  return { shuffled: shuffled.map((r) => mapValues(r, String)) }
+}
+
 export function destringifyShuffle({
-  // proof,
+  proof,
   shuffled,
-}: ReturnType<typeof stringifyShuffle>): AsyncReturnType<typeof shuffle> {
-  // const p = proof
-  // const simple = p.simple_shuffle_proof
+}: ReturnType<typeof stringifyShuffle>): AsyncReturnType<typeof shuffleWithProof> {
+  const p = proof
+  const simple = p.simple_shuffle_proof
   return {
-    // proof: {
-    //   As: p.As.map(RP.fromHex),
-    //   Cs: p.Cs.map(RP.fromHex),
-    //   Ds: p.Ds.map(RP.fromHex),
-    //   Gamma: RP.fromHex(p.Gamma),
-    //   H: RP.fromHex(p.H),
-    //   Lambda1: RP.fromHex(p.Lambda1),
-    //   Lambda2: RP.fromHex(p.Lambda2),
-    //   Us: p.Us.map(RP.fromHex),
-    //   Ws: p.Ws.map(RP.fromHex),
-    //   sigmas: p.sigmas.map(BigInt),
-    //   simple_shuffle_proof: {
-    //     Gamma: RP.fromHex(simple.Gamma),
-    //     Thetas: simple.Thetas.map(RP.fromHex),
-    //     Xs: simple.Xs.map(RP.fromHex),
-    //     Ys: simple.Ys.map(RP.fromHex),
-    //     alphas: simple.alphas.map(BigInt),
-    //   },
-    //   tau: BigInt(p.tau),
-    // },
+    proof: {
+      As: p.As.map(RP.fromHex),
+      Cs: p.Cs.map(RP.fromHex),
+      Ds: p.Ds.map(RP.fromHex),
+      Gamma: RP.fromHex(p.Gamma),
+      H: RP.fromHex(p.H),
+      Lambda1: RP.fromHex(p.Lambda1),
+      Lambda2: RP.fromHex(p.Lambda2),
+      Us: p.Us.map(RP.fromHex),
+      Ws: p.Ws.map(RP.fromHex),
+      sigmas: p.sigmas.map(BigInt),
+      simple_shuffle_proof: {
+        Gamma: RP.fromHex(simple.Gamma),
+        Thetas: simple.Thetas.map(RP.fromHex),
+        Xs: simple.Xs.map(RP.fromHex),
+        Ys: simple.Ys.map(RP.fromHex),
+        alphas: simple.alphas.map(BigInt),
+      },
+      tau: BigInt(p.tau),
+    },
     shuffled: shuffled.map((r) => mapValues(r, RP.fromHex)),
   }
+}
+
+export function destringifyShuffleWithoutProof({
+  shuffled,
+}: ReturnType<typeof stringifyShuffleWithoutProof>): AsyncReturnType<typeof shuffleWithoutProof> {
+  return { shuffled: shuffled.map((r) => mapValues(r, RP.fromHex)) }
 }

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -19,7 +19,7 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
     <div className="bg-white p-4 rounded-lg shadow-[0_2px_2px_hsla(0,0%,50%,0.333),0_4px_4px_hsla(0,0%,50%,0.333),0_6px_6px_hsla(0,0%,50%,0.333)]">
       {!proofsPage && (
         <>
-          <h3>Decrypted Votes</h3> <p>Anonymized for vote secrecy.</p>
+          <h3 className="mt-0 mb-1.5">Decrypted Votes</h3> <p>Anonymized for vote secrecy.</p>
         </>
       )}
       <table>
@@ -50,10 +50,6 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
         </tbody>
       </table>
       <style jsx>{`
-        h3 {
-          margin: 0 0 5px;
-        }
-
         p {
           margin-top: 0px;
           font-size: 13px;

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -70,10 +70,7 @@ function isTypeBudget(ballot_design: Item[], col: string) {
 function validate(vote: string) {
   if (!vote) return vote
   const errorStyling = `text-red-500 border-0 border-b border-red-500 border-dashed opacity-70`
-  let error: string = ''
-  if (Number(vote) < 0) error = 'Negative amounts not allowed'
-  if (Number.isNaN(Number(vote))) error = 'Not a number'
-  if (Number(vote) === Infinity) error = "Can't normalize Infinity"
+  const error = invalidBudgetValues(vote)
 
   if (error)
     return (
@@ -83,4 +80,11 @@ function validate(vote: string) {
     )
 
   return '$' + vote
+}
+
+function invalidBudgetValues(vote: string): string {
+  if (Number(vote) < 0) return 'Negative amounts not allowed'
+  if (Number.isNaN(Number(vote))) return 'Not a number'
+  if (Number(vote) === Infinity) return "Can't normalize Infinity"
+  return ''
 }

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -1,7 +1,7 @@
 import { orderBy } from 'lodash-es'
 import { generateColumnNames } from 'src/vote/generateColumnNames'
 
-import { BudgetEntry, findBudgetQuestion, sumBudgetVotes } from './tallyBudgetLogic'
+import { BudgetEntry, BudgetsAveraged, findBudgetQuestion, sumBudgetVotes } from './tallyBudgetLogic'
 import { unTruncateSelection } from './un-truncate-selection'
 import { useDecryptedVotes } from './use-decrypted-votes'
 import { useElectionInfo } from './use-election-info'
@@ -36,6 +36,7 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
           </tr>
         </thead>
         <tbody>
+          <BudgetsAveraged {...{ ballot_design, budgetSums, columns, sorted_votes }} />
           {sorted_votes.map((vote, voteIndex) => (
             <tr key={voteIndex}>
               <td>{voteIndex + 1}.</td>

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -16,7 +16,7 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
   const { columns } = generateColumnNames({ ballot_design })
 
   return (
-    <div>
+    <div className="bg-white p-4 rounded-lg shadow-[0_2px_2px_hsla(0,0%,50%,0.333),0_4px_4px_hsla(0,0%,50%,0.333),0_6px_6px_hsla(0,0%,50%,0.333)]">
       {!proofsPage && (
         <>
           <h3>Decrypted Votes</h3> <p>Anonymized for vote secrecy.</p>
@@ -50,14 +50,6 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
         </tbody>
       </table>
       <style jsx>{`
-        div {
-          background: #fff;
-          padding: 1rem;
-          border-radius: 8px;
-          box-shadow: 0px 2px 2px hsl(0 0% 50% / 0.333), 0px 4px 4px hsl(0 0% 50% / 0.333),
-            0px 6px 6px hsl(0 0% 50% / 0.333);
-        }
-
         h3 {
           margin: 0 0 5px;
         }

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -19,7 +19,8 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
     <div className="bg-white p-4 rounded-lg shadow-[0_2px_2px_hsla(0,0%,50%,0.333),0_4px_4px_hsla(0,0%,50%,0.333),0_6px_6px_hsla(0,0%,50%,0.333)]">
       {!proofsPage && (
         <>
-          <h3 className="mt-0 mb-1.5">Decrypted Votes</h3> <p>Anonymized for vote secrecy.</p>
+          <h3 className="mt-0 mb-1.5">Decrypted Votes</h3>
+          <p className="mt-0 text-[13px] italic opacity-70">Anonymized for vote secrecy.</p>
         </>
       )}
       <table>
@@ -50,13 +51,6 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
         </tbody>
       </table>
       <style jsx>{`
-        p {
-          margin-top: 0px;
-          font-size: 13px;
-          font-style: italic;
-          opacity: 0.7;
-        }
-
         table {
           border-collapse: collapse;
           display: block;

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -25,7 +25,7 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
       )}
       <table className="block overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px]">
         <thead>
-          <tr>
+          <tr className="text-[11px]">
             <th></th>
             <th style={{ backgroundColor: 'rgba(10, 232, 10, 0.24)' }}>verification #</th>
             {columns.map((c) => (
@@ -50,11 +50,6 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
           ))}
         </tbody>
       </table>
-      <style jsx>{`
-        th {
-          font-size: 11px;
-        }
-      `}</style>
     </div>
   )
 }

--- a/src/status/DecryptedVotes.tsx
+++ b/src/status/DecryptedVotes.tsx
@@ -23,7 +23,7 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
           <p className="mt-0 text-[13px] italic opacity-70">Anonymized for vote secrecy.</p>
         </>
       )}
-      <table>
+      <table className="block overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px]">
         <thead>
           <tr>
             <th></th>
@@ -51,19 +51,6 @@ export const DecryptedVotes = ({ proofsPage }: { proofsPage?: boolean }): JSX.El
         </tbody>
       </table>
       <style jsx>{`
-        table {
-          border-collapse: collapse;
-          display: block;
-          overflow: auto;
-        }
-
-        th,
-        td {
-          border: 1px solid #ccc;
-          padding: 3px 10px;
-          margin: 0;
-        }
-
         th {
           font-size: 11px;
         }

--- a/src/status/tally-votes.ts
+++ b/src/status/tally-votes.ts
@@ -4,9 +4,8 @@ import { Item } from 'src/vote/storeElectionInfo'
 import { mapValues } from '../utils'
 import { tally_IRV_Items } from './tallying/rcv-irv'
 
+export const multi_vote_regex = /_(\d+)$/
 export function tallyVotes(ballot_items_by_id: Record<string, Item>, votes: Record<string, string>[]) {
-  const multi_vote_regex = /_(\d+)$/
-
   // Sum up votes
   const tallies: Record<string, Record<string, number>> = {}
   const IRV_columns_seen: Record<string, boolean> = {}

--- a/src/status/tallyBudgetLogic.tsx
+++ b/src/status/tallyBudgetLogic.tsx
@@ -157,9 +157,18 @@ export function BudgetsAveraged({
       {columns.map((col, colIndex) => (
         <td className="text-center" key={col}>
           {averages[colIndex] === 0 ? (
-            <span className="opacity-30">0</span>
+            <span className="opacity-20">0</span>
           ) : (
-            <span>${Math.floor(averages[colIndex])}</span>
+            <Tooltip
+              tooltip={
+                <span>
+                  Mean of <span className="font-semibold text-green-800">normalized</span> amounts below{' '}
+                  <span className="opacity-50">(blanks = 0)</span>
+                </span>
+              }
+            >
+              <span className="font-semibold text-green-800">${Math.floor(averages[colIndex])}</span>
+            </Tooltip>
           )}
         </td>
       ))}

--- a/src/status/tallyBudgetLogic.tsx
+++ b/src/status/tallyBudgetLogic.tsx
@@ -1,0 +1,103 @@
+import { Tooltip } from 'src/admin/Voters/Tooltip'
+import { Item } from 'src/vote/storeElectionInfo'
+
+/** Find the original ballot_design id for a given column */
+export function findBudgetQuestion(ballot_design: Item[], col: string) {
+  // Check for matching ballot types = 'budget'
+  const possibleItem = ballot_design.find(({ id = 'vote', type }) => type === 'budget' && col.startsWith(id))
+  if (!possibleItem) return false
+
+  // If found, check if col is in options
+  const matchingCol = possibleItem.options.find(({ name, value }) => col.endsWith(value || name))
+
+  if (matchingCol) return possibleItem
+}
+
+function invalidBudgetValues(vote: string): string {
+  if (Number(vote) < 0) return 'Negative amounts not allowed'
+  if (Number.isNaN(Number(vote))) return 'Not a number'
+  if (Number(vote) === Infinity) return "Can't normalize Infinity"
+  return ''
+}
+
+export function sumBudgetVotes(votes: Record<string, string>[], ballot_design: Item[]) {
+  // For all budget questions
+  return ballot_design.map(({ id = 'vote', options, type }) => {
+    // Stop if question isn't a budget item
+    if (type !== 'budget') return []
+
+    // Otherwise, for every submission (row in table)
+    return votes.map((vote) => {
+      // Add up their total budget allocated
+      let total = 0
+      options.forEach(({ name, value }) => {
+        const cell = vote[id + '_' + value || name]
+
+        // Filter out invalid entries
+        if (invalidBudgetValues(cell)) return
+
+        total += Number(cell)
+      })
+      return total
+    })
+  })
+}
+
+export function BudgetEntry({
+  ballot_design,
+  budgetSums,
+  col,
+  original,
+  voteIndex,
+}: {
+  ballot_design: Item[]
+  budgetSums: number[][]
+  col: string
+  original: string
+  voteIndex: number
+}) {
+  // Handle blanks
+  if (!original) return null
+
+  // Handle invalid entries
+  const error = invalidBudgetValues(original)
+  if (error)
+    return (
+      <Tooltip tooltip={error}>
+        <span className="text-red-500 border-0 border-b border-red-500 border-dashed opacity-70">{original}</span>
+      </Tooltip>
+    )
+
+  // Find the right question
+  const question = findBudgetQuestion(ballot_design, col)
+  if (!question) return null
+  const questionIndex = ballot_design.findIndex(({ id }) => id === question?.id)
+
+  // Find the precalculated total budget allocated for this row
+  const total = budgetSums[questionIndex][voteIndex]
+
+  // If total === budget_allocated, return original
+  if (total === Number(original)) return <span className="text-green-800">${original}</span>
+
+  // Otherwise, we'll display normalized
+  const factor = (question.budget_available || 0) / total
+  const normalized = Number(original) * factor
+  return (
+    <Tooltip
+      tooltip={
+        <span className="text-black/50">
+          Row total: <span className="text-black/80">${total}</span> of ${question.budget_available}. Scaling by{' '}
+          <span className="font-semibold text-green-800">{factor.toFixed(2)}</span>
+        </span>
+      }
+    >
+      <div>
+        <span className="opacity-80">{original}</span>
+        <span className="opacity-40"> → </span>
+        <span className="text-green-800 border-0 border-b border-dashed border-green-800/70 ">
+          ${Math.floor(normalized)}
+        </span>
+      </div>
+    </Tooltip>
+  )
+}

--- a/src/status/tallying/rcv-irv.test.ts
+++ b/src/status/tallying/rcv-irv.test.ts
@@ -166,4 +166,5 @@ describe('IRV tallying', () => {
   test.todo('handles when there is a tie in the bottom choice')
   test.todo('handles when there is a tie in the top choice early on')
   test.todo('handles when there is a tie in the final round')
+  test.todo('handles when there are a two digit number of multiple_votes_allowed')
 })

--- a/src/status/tallying/rcv-irv.test.ts
+++ b/src/status/tallying/rcv-irv.test.ts
@@ -163,6 +163,8 @@ describe('IRV tallying', () => {
     expect(rounds[2].tallies).toEqual({ 'Abraham Lincoln': 4, 'Bill Clinton': 5 })
   })
 
+  test.todo('handles when there are a large number of distinct write-ins') // See https://siv.org/election/1721314324882
+
   test.todo('handles when there is a tie in the bottom choice')
   test.todo('handles when there is a tie in the top choice early on')
   test.todo('handles when there is a tie in the final round')

--- a/src/trustee/decrypt/PrivateKeyshare.tsx
+++ b/src/trustee/decrypt/PrivateKeyshare.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+import { PrivateBox } from '../PrivateBox'
+
+export const PrivateKeyshare = ({ private_keyshare }: { private_keyshare: string }) => {
+  const [blurred, setBlurred] = useState(true)
+
+  return (
+    <div className="mt-8">
+      <PrivateBox>
+        <p>
+          Your Private keyshare is:{' '}
+          <span className={`font-mono cursor-pointer ${blurred && 'blur-sm'}`} onClick={() => setBlurred(!blurred)}>
+            {!blurred ? private_keyshare : blurredTextMask(private_keyshare.length)}
+          </span>
+        </p>
+      </PrivateBox>
+    </div>
+  )
+}
+
+function blurredTextMask(length: number) {
+  let newString = ''
+  const blurred_text = 'BLURRED&TEXTREPLACEDBECAUSEJUSTBLURRINGALONECANBEUNDONEPRETTYEASILYACTUALLY.'
+  for (let i = 0; i < length; i += blurred_text.length) {
+    newString += blurred_text
+  }
+  return newString.slice(0, length)
+}

--- a/src/trustee/decrypt/ShuffleAndDecrypt.tsx
+++ b/src/trustee/decrypt/ShuffleAndDecrypt.tsx
@@ -32,7 +32,7 @@ export const ShuffleAndDecrypt = ({ dispatch, state }: StateAndDispatch): JSX.El
       </PrivateBox>
 
       {/* All Accepted Votes */}
-      <AcceptedVotes {...{ ballot_design }} title_prefix="II. " />
+      <AcceptedVotes {...{ ballot_design }} allow_truncation title_prefix="II. " />
 
       {/* Are there new votes shuffled from the trustee ahead of us that we need to shuffle? */}
       <VotesToShuffle {...{ dispatch, final_shuffle_verifies, set_final_shuffle_verifies, state }} />

--- a/src/trustee/decrypt/ShuffleAndDecrypt.tsx
+++ b/src/trustee/decrypt/ShuffleAndDecrypt.tsx
@@ -11,7 +11,7 @@ import { VotesToShuffle } from './VotesToShuffle'
 
 export const ShuffleAndDecrypt = ({ dispatch, state }: StateAndDispatch): JSX.Element => {
   const { private_keyshare } = state
-  const { ballot_design } = useElectionInfo()
+  const { ballot_design, skip_shuffle_proofs } = useElectionInfo()
   const [final_shuffle_verifies, set_final_shuffle_verifies] = useState(false)
 
   if (!private_keyshare) return <p>Error: No `private_keyshare` found in localStorage.</p>
@@ -32,7 +32,9 @@ export const ShuffleAndDecrypt = ({ dispatch, state }: StateAndDispatch): JSX.El
       <AcceptedVotes {...{ ballot_design }} allow_truncation title_prefix="II. " />
 
       {/* Are there new votes shuffled from the trustee ahead of us that we need to shuffle? */}
-      <VotesToShuffle {...{ dispatch, final_shuffle_verifies, set_final_shuffle_verifies, state }} />
+      <VotesToShuffle
+        {...{ dispatch, final_shuffle_verifies, set_final_shuffle_verifies, skip_shuffle_proofs, state }}
+      />
 
       {/* Are there fully shuffled votes we need to partially decrypt? */}
       <VotesToDecrypt {...{ dispatch, final_shuffle_verifies, state }} />

--- a/src/trustee/decrypt/ShuffleAndDecrypt.tsx
+++ b/src/trustee/decrypt/ShuffleAndDecrypt.tsx
@@ -3,9 +3,9 @@ import { useState } from 'react'
 import { AcceptedVotes } from '../../status/AcceptedVotes'
 import { useElectionInfo } from '../../status/use-election-info'
 import { Trustees } from '../keygen/1-Trustees'
-import { PrivateBox } from '../PrivateBox'
 import { StateAndDispatch } from '../trustee-state'
 import { ResetButton } from './_ResetButton'
+import { PrivateKeyshare } from './PrivateKeyshare'
 import { VotesToDecrypt } from './VotesToDecrypt'
 import { VotesToShuffle } from './VotesToShuffle'
 
@@ -26,10 +26,7 @@ export const ShuffleAndDecrypt = ({ dispatch, state }: StateAndDispatch): JSX.El
       <Trustees {...{ state }} />
 
       {/* Do we have a private keyshare stored? */}
-      <br />
-      <PrivateBox>
-        <p>Your Private keyshare is: {private_keyshare}</p>
-      </PrivateBox>
+      <PrivateKeyshare {...{ private_keyshare }} />
 
       {/* All Accepted Votes */}
       <AcceptedVotes {...{ ballot_design }} allow_truncation title_prefix="II. " />

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../crypto/threshold-keygen'
 import { Partial, StateAndDispatch } from '../trustee-state'
 import { YouLabel } from '../YouLabel'
+import { useTruncatedTable } from './useTruncatedTable'
 
 type Partials = Record<string, Partial[]>
 type Validations_Table = Record<string, Record<string, (boolean | null)[]>>
@@ -177,36 +178,45 @@ const PartialsTable = ({
   const trustees_validations = validated_proofs[email]
   if (!trustees_validations) return <></>
   const columns = Object.keys(partials)
+  const { TruncationToggle, rows_to_show } = useTruncatedTable({
+    num_cols: columns.length,
+    num_rows: Object.values(partials)[0].length,
+  })
+
   return (
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          {columns.map((c) => (
-            <th key={c}>{c}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {partials[columns[0]].map((_, index) => (
-          <tr key={index}>
-            <td>{index + 1}.</td>
-            {columns.map((key) => {
-              const validated = trustees_validations[key][index]
-              return (
-                <Fragment key={key}>
-                  <td className="monospaced">
-                    <div>
-                      {partials[key][index].partial}{' '}
-                      <span>{validated === null ? <LoadingOutlined /> : validated ? '' : '❌'}</span>
-                    </div>
-                  </td>
-                </Fragment>
-              )
-            })}
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            {columns.map((c) => (
+              <th key={c}>{c}</th>
+            ))}
           </tr>
-        ))}
-      </tbody>
+        </thead>
+        <tbody>
+          {partials[columns[0]].slice(0, rows_to_show).map((_, index) => (
+            <tr key={index}>
+              <td>{index + 1}.</td>
+              {columns.map((key) => {
+                const validated = trustees_validations[key][index]
+                return (
+                  <Fragment key={key}>
+                    <td className="monospaced">
+                      <div>
+                        {partials[key][index].partial}{' '}
+                        <span>{validated === null ? <LoadingOutlined /> : validated ? '' : '❌'}</span>
+                      </div>
+                    </td>
+                  </Fragment>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <TruncationToggle />
+
       <style jsx>{`
         table {
           border-collapse: collapse;
@@ -245,7 +255,7 @@ const PartialsTable = ({
           font-weight: 700;
         }
       `}</style>
-    </table>
+    </>
   )
 }
 

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -180,12 +180,12 @@ const PartialsTable = ({
   validated_proofs: Validations_Table
 }): JSX.Element => {
   const trustees_validations = validated_proofs[email]
-  if (!trustees_validations) return <></>
   const columns = sortColumnsForTrustees(Object.keys(partials))
   const { TruncationToggle, rows_to_show } = useTruncatedTable({
     num_cols: columns.length,
     num_rows: Object.values(partials)[0].length,
   })
+  if (!trustees_validations) return <></>
 
   return (
     <>

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -190,8 +190,8 @@ const PartialsTable = ({
   return (
     <>
       <table className="block w-full pb-3 overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>td]:pr-5 [&_tr>*]:py-[3px]">
-        <thead>
-          <tr className="text-[11px]">
+        <thead className="text-[11px] text-center">
+          <tr>
             <th></th>
             {columns.map((c) => (
               <th key={c}>{c}</th>

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -100,7 +100,7 @@ export const VotesToDecrypt = ({
 
   async function partialDecryptFinalShuffle() {
     console.log(
-      `Last trusteee has shuffled: ${num_last_shuffled}, We decrypted: ${num_we_decrypted}. Beginning partial decryption...`,
+      `Last trustee has shuffled: ${num_last_shuffled}, We decrypted: ${num_we_decrypted}. Beginning partial decryption...`,
     )
 
     // Partially decrypt each item in every list

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -188,30 +188,30 @@ const PartialsTable = ({
 
   return (
     <>
-      <table>
+      <table className="block w-full pb-3 overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>td]:pr-5 [&_tr>*]:py-[3px]">
         <thead>
-          <tr>
+          <tr className="text-[11px]">
             <th></th>
             {columns.map((c) => (
               <th key={c}>{c}</th>
             ))}
           </tr>
         </thead>
-        <tbody>
+        <tbody className="[&>tr>*]:max-w-[239px]">
           {partials[columns[0]].slice(0, rows_to_show).map((_, index) => (
             <tr key={index}>
-              <td>{index + 1}.</td>
+              <td className="!pr-2.5">{index + 1}.</td>
               {columns.map((key) => {
                 const validated = trustees_validations[key][index]
                 return (
-                  <Fragment key={key}>
-                    <td className="monospaced">
-                      <div>
-                        {partials[key][index].partial}{' '}
-                        <span>{validated === null ? <LoadingOutlined /> : validated ? '' : '❌'}</span>
-                      </div>
-                    </td>
-                  </Fragment>
+                  <td className="font-mono text-[10px]" key={key}>
+                    <div className="relative">
+                      {partials[key][index].partial}{' '}
+                      <span className="absolute top-2 -right-3.5 text-[10px] opacity-30">
+                        {validated === null ? <LoadingOutlined /> : validated ? '' : '❌'}
+                      </span>
+                    </div>
+                  </td>
                 )
               })}
             </tr>
@@ -219,45 +219,6 @@ const PartialsTable = ({
         </tbody>
       </table>
       <TruncationToggle />
-
-      <style jsx>{`
-        table {
-          border-collapse: collapse;
-          display: block;
-          overflow: auto;
-          margin-bottom: 15px;
-        }
-
-        th,
-        td {
-          border: 1px solid #ccc;
-          padding: 3px 10px;
-          padding-right: 20px;
-          margin: 0;
-          max-width: 250px;
-        }
-        td div {
-          position: relative;
-        }
-
-        td span {
-          position: absolute;
-          top: 1px;
-          right: -16px;
-          font-size: 10px;
-          opacity: 0.3;
-        }
-
-        td.monospaced {
-          font-family: monospace;
-        }
-
-        th,
-        .subheading td {
-          font-size: 11px;
-          font-weight: 700;
-        }
-      `}</style>
     </>
   )
 }
@@ -267,14 +228,9 @@ const DecryptionProof = ({ partials }: { partials: Partials }) => (
     {Object.keys(partials).map((column) => (
       <div key={column}>
         <h4>{column}</h4>
-        <code>{JSON.stringify(partials[column])}</code>
+        <code className="text-[13px]">{JSON.stringify(partials[column])}</code>
       </div>
     ))}
-    <style jsx>{`
-      code {
-        font-size: 13px;
-      }
-    `}</style>
   </>
 )
 

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -2,7 +2,7 @@
 import { LoadingOutlined } from '@ant-design/icons'
 import bluebird from 'bluebird'
 import { mapValues } from 'lodash-es'
-import { Dispatch, Fragment, SetStateAction, useEffect, useReducer, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useReducer, useState } from 'react'
 import { RP } from 'src/crypto/curve'
 import { destringifyPartial, stringifyPartial } from 'src/crypto/stringify-partials'
 
@@ -16,6 +16,7 @@ import {
 import { Partial, StateAndDispatch } from '../trustee-state'
 import { YouLabel } from '../YouLabel'
 import { useTruncatedTable } from './useTruncatedTable'
+import { sortColumnsForTrustees } from './VotesToShuffle'
 
 type Partials = Record<string, Partial[]>
 type Validations_Table = Record<string, Record<string, (boolean | null)[]>>
@@ -180,7 +181,7 @@ const PartialsTable = ({
 }): JSX.Element => {
   const trustees_validations = validated_proofs[email]
   if (!trustees_validations) return <></>
-  const columns = Object.keys(partials)
+  const columns = sortColumnsForTrustees(Object.keys(partials))
   const { TruncationToggle, rows_to_show } = useTruncatedTable({
     num_cols: columns.length,
     num_rows: Object.values(partials)[0].length,

--- a/src/trustee/decrypt/VotesToDecrypt.tsx
+++ b/src/trustee/decrypt/VotesToDecrypt.tsx
@@ -140,14 +140,22 @@ export const VotesToDecrypt = ({
   return (
     <>
       <h3>IV. Votes to Decrypt</h3>
-      <ol>
+      <ol className="pl-5">
         {trustees?.map(({ email, partials, you }) => (
-          <li key={email}>
-            {email}
-            {you && <YouLabel />} partially decrypted {!partials ? 0 : Object.values(partials)[0].length} votes.
-            {partials && (
-              <ValidationSummary {...{ email, partials, proofs_shown, set_proofs_shown, validated_proofs }} />
-            )}
+          <li className="mb-8" key={email}>
+            {/* Top row */}
+            <div className="flex flex-col justify-between sm:flex-row">
+              {/* Left */}
+              <span>
+                {email}
+                {you && <YouLabel />} partially decrypted {!partials ? 0 : Object.values(partials)[0].length}
+                &nbsp;votes.
+              </span>
+              {/* Right */}
+              {partials && (
+                <ValidationSummary {...{ email, partials, proofs_shown, set_proofs_shown, validated_proofs }} />
+              )}
+            </div>
             {partials && (
               <>
                 <PartialsTable {...{ email, partials, validated_proofs }} />
@@ -157,11 +165,6 @@ export const VotesToDecrypt = ({
           </li>
         ))}
       </ol>
-      <style jsx>{`
-        li {
-          margin-bottom: 2rem;
-        }
-      `}</style>
     </>
   )
 }
@@ -298,30 +301,16 @@ const ValidationSummary = ({
   const num_total_partials = !partials ? 0 : num_votes_decrypted * Object.keys(partials).length
 
   return (
-    <i>
+    <i className="sm:text-right text-[11px] block">
       {!!num_partials_passed && num_partials_passed === num_total_partials && '✅ '}
       {num_partials_passed} of {num_total_partials} Decryption Proofs verified (
-      <a className="show-proof" onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}>
+      <a
+        className="font-mono cursor-pointer"
+        onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}
+      >
         {proofs_shown[email] ? '-Hide' : '+Show'}
       </a>
       )
-      <style jsx>{`
-        i {
-          font-size: 11px;
-          display: block;
-        }
-
-        @media (min-width: 600px) {
-          i {
-            float: right;
-          }
-        }
-
-        .show-proof {
-          cursor: pointer;
-          font-family: monospace;
-        }
-      `}</style>
     </i>
   )
 }

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -148,7 +148,8 @@ export const VotesToShuffle = ({
         {trustees?.map(({ email, shuffled, you }) => (
           <li key={email}>
             {email}
-            {you && <YouLabel />} shuffled {!shuffled ? '0' : Object.values(shuffled)[0].shuffled.length} votes.
+            {you && <YouLabel />} shuffled {!shuffled ? '0' : Object.values(shuffled)[0].shuffled.length} votes
+            {shuffled && ` x ${Object.keys(shuffled).length} columns`}.
             {shuffled && (
               <ValidationSummary {...{ email, proofs_shown, set_proofs_shown, shuffled, validated_proofs }} />
             )}

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -147,7 +147,7 @@ export const VotesToShuffle = ({
       <h3>III. Votes to Shuffle</h3>
       <ol>
         {trustees?.map(({ email, shuffled, you }) => (
-          <li key={email}>
+          <li className="mb-8" key={email}>
             {email}
             {you && <YouLabel />} shuffled {!shuffled ? '0' : Object.values(shuffled)[0].shuffled.length} votes
             {shuffled && ` x ${Object.keys(shuffled).length} columns`}.
@@ -163,11 +163,6 @@ export const VotesToShuffle = ({
           </li>
         ))}
       </ol>
-      <style jsx>{`
-        li {
-          margin-bottom: 2rem;
-        }
-      `}</style>
     </>
   )
 }

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -197,31 +197,33 @@ const ShuffledVotesTable = ({
 
   return (
     <>
-      <table>
-        <thead>
+      <table className="block w-full pb-3 overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px] [&_tr>*]:max-w-[227px]">
+        <thead className="text-[11px]">
           <tr>
-            <th></th>
+            <td rowSpan={2}></td>
             {columns.map((c) => {
               const verified = trustees_validations ? trustees_validations.columns[c] : null
               return (
                 <th colSpan={2} key={c}>
-                  {c} <span>{verified === null ? <LoadingOutlined /> : verified ? '' : '❌'}</span>
+                  {c}{' '}
+                  <span className="pl-[5px] opacity-50">
+                    {verified === null ? <LoadingOutlined /> : verified ? '' : '❌'}
+                  </span>
                 </th>
               )
             })}
           </tr>
-        </thead>
-        <tbody>
           {/* Column subheadings */}
-          <tr className="subheading">
-            <td></td>
+          <tr>
             {columns.map((c) => (
               <Fragment key={c}>
-                <td>encrypted</td>
-                <td>lock</td>
+                <th>encrypted</th>
+                <th>lock</th>
               </Fragment>
             ))}
           </tr>
+        </thead>
+        <tbody>
           {shuffled[columns[0]].shuffled.slice(0, rows_to_show).map((_, index) => (
             <tr key={index}>
               <td>{index + 1}.</td>
@@ -229,8 +231,8 @@ const ShuffledVotesTable = ({
                 const cipher = shuffled[key].shuffled[index]
                 return (
                   <Fragment key={key}>
-                    <td className="monospaced">{cipher.encrypted}</td>
-                    <td className="monospaced">{cipher.lock}</td>
+                    <td className="font-mono text-[10px]">{cipher.encrypted}</td>
+                    <td className="font-mono text-[10px]">{cipher.lock}</td>
                   </Fragment>
                 )
               })}
@@ -239,38 +241,6 @@ const ShuffledVotesTable = ({
         </tbody>
       </table>
       <TruncationToggle />
-
-      <style jsx>{`
-        table {
-          border-collapse: collapse;
-          display: block;
-          overflow: auto;
-          margin-bottom: 10px;
-        }
-
-        th,
-        td {
-          border: 1px solid #ccc;
-          padding: 3px 10px;
-          margin: 0;
-          max-width: 240px;
-        }
-
-        td.monospaced {
-          font-family: monospace;
-        }
-
-        th,
-        .subheading td {
-          font-size: 11px;
-          font-weight: 700;
-        }
-
-        th span {
-          padding-left: 5px;
-          opacity: 0.6;
-        }
-      `}</style>
     </>
   )
 }

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -274,14 +274,9 @@ const ShuffleProof = ({ shuffled }: { shuffled: Shuffled }) => (
     {Object.keys(shuffled).map((column) => (
       <div key={column}>
         <h4>{column}</h4>
-        {/* <code>{JSON.stringify(shuffled[column].proof)}</code> */}
+        {/* <code className="text-[13px]">{JSON.stringify(shuffled[column].proof)}</code> */}
       </div>
     ))}
-    <style jsx>{`
-      code {
-        font-size: 13px;
-      }
-    `}</style>
   </>
 )
 
@@ -299,30 +294,16 @@ const ValidationSummary = ({
   const validations = validated_proofs[email]
 
   return (
-    <i>
+    <i className="text-[11px] block sm:float-right">
       {all_proofs_passed(validations) && '✅ '}
       {num_proofs_passed(validations)} of {num_total_proofs(validations)} Shuffle Proofs verified (
-      <a className="show-proof" onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}>
+      <a
+        className="font-mono cursor-pointer"
+        onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}
+      >
         {proofs_shown[email] ? '-Hide' : '+Show'}
       </a>
       )
-      <style jsx>{`
-        i {
-          font-size: 11px;
-          display: block;
-        }
-
-        @media (min-width: 600px) {
-          i {
-            float: right;
-          }
-        }
-
-        .show-proof {
-          cursor: pointer;
-          font-family: monospace;
-        }
-      `}</style>
     </i>
   )
 }

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -116,6 +116,7 @@ export const VotesToShuffle = ({
         ),
       ),
     )
+    console.log('Shuffled complete.')
 
     // Tell admin our new shuffled list
     api(`election/${state.election_id}/trustees/update`, {

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -252,10 +252,12 @@ const ShuffledVotesTable = ({
 
 const ShuffleProof = ({ shuffled }: { shuffled: Shuffled }) => (
   <>
-    {Object.keys(shuffled).map((column) => (
+    {sortColumnsForTrustees(Object.keys(shuffled)).map((column) => (
       <div key={column}>
-        <h4>{column}</h4>
-        {/* <code className="text-[13px]">{JSON.stringify(shuffled[column].proof)}</code> */}
+        <h4>{column} — shuffle proof</h4>
+        <code className="text-[13px] overflow-y-scroll max-h-96 block bg-black/5 p-2 rounded">
+          {JSON.stringify(shuffled[column].proof)}
+        </code>
       </div>
     ))}
   </>
@@ -278,14 +280,15 @@ const ValidationSummary = ({
     <i className="text-[11px] block sm:text-right">
       {SKIP_SHUFFLE_PROOFS ? '⏸️ ' : all_proofs_passed(validations) && '✅ '}
       {num_proofs_passed(validations)} of {num_total_proofs(validations)} Shuffle Proofs{' '}
-      {SKIP_SHUFFLE_PROOFS ? 'skipped' : 'verified'} (
-      <a
-        className="font-mono cursor-pointer"
-        onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}
-      >
-        {proofs_shown[email] ? '-Hide' : '+Show'}
-      </a>
-      )
+      {SKIP_SHUFFLE_PROOFS ? 'skipped' : 'verified'}{' '}
+      {!SKIP_SHUFFLE_PROOFS && (
+        <a
+          className="font-mono cursor-pointer"
+          onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}
+        >
+          {proofs_shown[email] ? '-Hide' : '+Show'}
+        </a>
+      )}
     </i>
   )
 }

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -188,7 +188,7 @@ const ShuffledVotesTable = ({
   validated_proofs: Validations_Table
 }): JSX.Element => {
   const trustees_validations = validated_proofs && validated_proofs[email]
-  const columns = Object.keys(shuffled)
+  const columns = sortColumnsForTrustees(Object.keys(shuffled))
 
   const { TruncationToggle, rows_to_show } = useTruncatedTable({
     num_cols: columns.length,
@@ -292,3 +292,21 @@ const num_total_proofs = (validations: Validations_Table['email']) =>
 
 const all_proofs_passed = (validations: Validations_Table['email']) =>
   !!num_proofs_passed(validations) && num_proofs_passed(validations) === num_total_proofs(validations)
+
+/** First tries to sort alphabetically, then numerically.
+Useful for sorting vote column names when you don't have ballot_schema easily accessible.
+If you do, just use generateColumns(), which will preserve ballot display order too. */
+export function sortColumnsForTrustees(data: string[]): string[] {
+  return [...data].sort((a, b) => {
+    // Extract the non-numeric and numeric parts of the strings
+    const regex = /^(.*?)(\d*)$/
+    const [, textA, numA] = a.match(regex) || []
+    const [, textB, numB] = b.match(regex) || []
+
+    // Compare the textual part
+    if (textA !== textB) return textA.localeCompare(textB)
+
+    // If textual part is the same, compare the numeric part (if present)
+    return (+numA || 0) - (+numB || 0)
+  })
+}

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -271,8 +271,8 @@ const ValidationSummary = ({
 
   return (
     <i className="text-[11px] block sm:text-right">
-      {all_proofs_passed(validations) && '✅ '}
-      {num_proofs_passed(validations)} of {num_total_proofs(validations)} Shuffle Proofs verified (
+      {all_proofs_passed(validations) && '⏸️ '}
+      {num_proofs_passed(validations)} of {num_total_proofs(validations)} Shuffle Proofs skipped (
       <a
         className="font-mono cursor-pointer"
         onClick={() => set_proofs_shown({ ...proofs_shown, [email]: !proofs_shown[email] })}

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -17,6 +17,8 @@ import { useTruncatedTable } from './useTruncatedTable'
 
 type Validations_Table = Record<string, { columns: Record<string, boolean | null>; num_votes: number }>
 
+const nbsp = '\u00A0'
+
 export const VotesToShuffle = ({
   set_final_shuffle_verifies,
   state,
@@ -145,15 +147,24 @@ export const VotesToShuffle = ({
   return (
     <>
       <h3>III. Votes to Shuffle</h3>
-      <ol>
+      <ol className="pl-5">
         {trustees?.map(({ email, shuffled, you }) => (
           <li className="mb-8" key={email}>
-            {email}
-            {you && <YouLabel />} shuffled {!shuffled ? '0' : Object.values(shuffled)[0].shuffled.length} votes
-            {shuffled && ` x ${Object.keys(shuffled).length} columns`}.
-            {shuffled && (
-              <ValidationSummary {...{ email, proofs_shown, set_proofs_shown, shuffled, validated_proofs }} />
-            )}
+            {/* Top row above table */}
+            <div className="flex flex-col justify-between sm:flex-row">
+              {/* Left */}
+              <span>
+                {email}
+                {you && <YouLabel />} shuffled {!shuffled ? '0' : Object.values(shuffled)[0].shuffled.length}&nbsp;votes
+                {shuffled && `${nbsp}x${nbsp}${Object.keys(shuffled).length}${nbsp}columns`}.
+              </span>
+              {/* Right */}
+              {shuffled && (
+                <ValidationSummary {...{ email, proofs_shown, set_proofs_shown, shuffled, validated_proofs }} />
+              )}
+            </div>
+
+            {/* Table */}
             {shuffled && (
               <>
                 <ShuffledVotesTable {...{ email, shuffled, validated_proofs }} />
@@ -289,7 +300,7 @@ const ValidationSummary = ({
   const validations = validated_proofs[email]
 
   return (
-    <i className="text-[11px] block sm:float-right">
+    <i className="text-[11px] block sm:text-right">
       {all_proofs_passed(validations) && '✅ '}
       {num_proofs_passed(validations)} of {num_total_proofs(validations)} Shuffle Proofs verified (
       <a

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -198,7 +198,7 @@ const ShuffledVotesTable = ({
   return (
     <>
       <table className="block w-full pb-3 overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px] [&_tr>*]:max-w-[227px]">
-        <thead className="text-[11px]">
+        <thead className="text-[11px] text-center">
           <tr>
             <td rowSpan={2}></td>
             {columns.map((c) => {

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -4,11 +4,13 @@ import bluebird from 'bluebird'
 import { mapValues } from 'lodash-es'
 import { Dispatch, Fragment, SetStateAction, useEffect, useReducer, useState } from 'react'
 import { RP } from 'src/crypto/curve'
-import { destringifyShuffle, stringifyShuffle } from 'src/crypto/stringify-shuffle'
+// import { destringifyShuffle, stringifyShuffle } from 'src/crypto/stringify-shuffle'
+import { stringifyShuffle } from 'src/crypto/stringify-shuffle'
 
 import { api } from '../../api-helper'
-import { rename_to_c1_and_2, shuffle } from '../../crypto/shuffle'
-import { verify_shuffle_proof } from '../../crypto/shuffle-proof'
+import { shuffle } from '../../crypto/shuffle'
+// import { rename_to_c1_and_2, shuffle } from '../../crypto/shuffle'
+// import { verify_shuffle_proof } from '../../crypto/shuffle-proof'
 import { Shuffled, StateAndDispatch } from '../trustee-state'
 import { YouLabel } from '../YouLabel'
 
@@ -76,19 +78,20 @@ export const VotesToShuffle = ({
 
       // Begin (async) validating each proof...
       Object.keys(trustee_validations).forEach((column) => {
-        // Inputs are the previous party's outputs
-        // except for admin, who provides the original split list.
-        const inputs = index > 0 ? trustees[index - 1].shuffled![column].shuffled : trustees[0].preshuffled![column]
+        set_validated_proofs({ column, email, result: true, type: 'UPDATE' })
+        // // Inputs are the previous party's outputs
+        // // except for admin, who provides the original split list.
+        // const inputs = index > 0 ? trustees[index - 1].shuffled![column].shuffled : trustees[0].preshuffled![column]
 
-        const { proof, shuffled: shuffledCol } = destringifyShuffle(shuffled[column])
+        // const { proof, shuffled: shuffledCol } = destringifyShuffle(shuffled[column])
 
-        verify_shuffle_proof(
-          rename_to_c1_and_2(inputs.map((c) => mapValues(c, RP.fromHex))),
-          rename_to_c1_and_2(shuffledCol),
-          proof,
-        ).then((result) => {
-          set_validated_proofs({ column, email, result, type: 'UPDATE' })
-        })
+        // verify_shuffle_proof(
+        //   rename_to_c1_and_2(inputs.map((c) => mapValues(c, RP.fromHex))),
+        //   rename_to_c1_and_2(shuffledCol),
+        //   proof,
+        // ).then((result) => {
+        //   set_validated_proofs({ column, email, result, type: 'UPDATE' })
+        // })
       })
     })
   }, [num_shuffled_from_trustees])
@@ -258,7 +261,7 @@ const ShuffleProof = ({ shuffled }: { shuffled: Shuffled }) => (
     {Object.keys(shuffled).map((column) => (
       <div key={column}>
         <h4>{column}</h4>
-        <code>{JSON.stringify(shuffled[column].proof)}</code>
+        {/* <code>{JSON.stringify(shuffled[column].proof)}</code> */}
       </div>
     ))}
     <style jsx>{`

--- a/src/trustee/decrypt/VotesToShuffle.tsx
+++ b/src/trustee/decrypt/VotesToShuffle.tsx
@@ -13,6 +13,7 @@ import { shuffle } from '../../crypto/shuffle'
 // import { verify_shuffle_proof } from '../../crypto/shuffle-proof'
 import { Shuffled, StateAndDispatch } from '../trustee-state'
 import { YouLabel } from '../YouLabel'
+import { useTruncatedTable } from './useTruncatedTable'
 
 type Validations_Table = Record<string, { columns: Record<string, boolean | null>; num_votes: number }>
 
@@ -182,47 +183,57 @@ const ShuffledVotesTable = ({
 }): JSX.Element => {
   const trustees_validations = validated_proofs && validated_proofs[email]
   const columns = Object.keys(shuffled)
+
+  const { TruncationToggle, rows_to_show } = useTruncatedTable({
+    num_cols: columns.length,
+    num_rows: Object.values(shuffled)[0].shuffled.length,
+  })
+
   return (
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          {columns.map((c) => {
-            const verified = trustees_validations ? trustees_validations.columns[c] : null
-            return (
-              <th colSpan={2} key={c}>
-                {c} <span>{verified === null ? <LoadingOutlined /> : verified ? '' : '❌'}</span>
-              </th>
-            )
-          })}
-        </tr>
-      </thead>
-      <tbody>
-        {/* Column subheadings */}
-        <tr className="subheading">
-          <td></td>
-          {columns.map((c) => (
-            <Fragment key={c}>
-              <td>encrypted</td>
-              <td>lock</td>
-            </Fragment>
-          ))}
-        </tr>
-        {shuffled[columns[0]].shuffled.map((_, index) => (
-          <tr key={index}>
-            <td>{index + 1}.</td>
-            {columns.map((key) => {
-              const cipher = shuffled[key].shuffled[index]
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            {columns.map((c) => {
+              const verified = trustees_validations ? trustees_validations.columns[c] : null
               return (
-                <Fragment key={key}>
-                  <td className="monospaced">{cipher.encrypted}</td>
-                  <td className="monospaced">{cipher.lock}</td>
-                </Fragment>
+                <th colSpan={2} key={c}>
+                  {c} <span>{verified === null ? <LoadingOutlined /> : verified ? '' : '❌'}</span>
+                </th>
               )
             })}
           </tr>
-        ))}
-      </tbody>
+        </thead>
+        <tbody>
+          {/* Column subheadings */}
+          <tr className="subheading">
+            <td></td>
+            {columns.map((c) => (
+              <Fragment key={c}>
+                <td>encrypted</td>
+                <td>lock</td>
+              </Fragment>
+            ))}
+          </tr>
+          {shuffled[columns[0]].shuffled.slice(0, rows_to_show).map((_, index) => (
+            <tr key={index}>
+              <td>{index + 1}.</td>
+              {columns.map((key) => {
+                const cipher = shuffled[key].shuffled[index]
+                return (
+                  <Fragment key={key}>
+                    <td className="monospaced">{cipher.encrypted}</td>
+                    <td className="monospaced">{cipher.lock}</td>
+                  </Fragment>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <TruncationToggle />
+
       <style jsx>{`
         table {
           border-collapse: collapse;
@@ -254,7 +265,7 @@ const ShuffledVotesTable = ({
           opacity: 0.6;
         }
       `}</style>
-    </table>
+    </>
   )
 }
 

--- a/src/trustee/decrypt/useTruncatedTable.tsx
+++ b/src/trustee/decrypt/useTruncatedTable.tsx
@@ -20,11 +20,13 @@ export const useTruncatedTable = ({
     if (!any_to_truncate) return null
 
     return (
-      <a className="block text-center opacity-50 cursor-pointer" onClick={() => setTruncated(!isTruncated)}>
-        {isTruncated
-          ? `...and ${Math.ceil(num_rows - num_truncated_rows)} more rows.`
-          : `Truncate to < ${max_cells_to_show} total selections.`}
-      </a>
+      <div>
+        <a className="text-xs text-center opacity-50 cursor-pointer" onClick={() => setTruncated(!isTruncated)}>
+          {isTruncated
+            ? `...and ${Math.ceil(num_rows - num_truncated_rows)} more rows.`
+            : `Truncate to < ${max_cells_to_show} total selections.`}
+        </a>
+      </div>
     )
   }
 

--- a/src/trustee/decrypt/useTruncatedTable.tsx
+++ b/src/trustee/decrypt/useTruncatedTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export const useTruncatedTable = ({
   max_cells_to_show = 50,
@@ -12,6 +12,8 @@ export const useTruncatedTable = ({
   const num_truncated_rows = Math.floor(max_cells_to_show / num_cols)
   const any_to_truncate = num_rows > num_truncated_rows
   const [isTruncated, setTruncated] = useState(any_to_truncate)
+  useEffect(() => setTruncated(any_to_truncate), [any_to_truncate]) // In case data loads after init render
+
   const rows_to_show = isTruncated ? num_truncated_rows : num_rows
 
   function TruncationToggle() {

--- a/src/trustee/decrypt/useTruncatedTable.tsx
+++ b/src/trustee/decrypt/useTruncatedTable.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+export const useTruncatedTable = ({
+  max_cells_to_show = 50,
+  num_cols,
+  num_rows,
+}: {
+  max_cells_to_show?: number
+  num_cols: number
+  num_rows: number
+}) => {
+  const num_truncated_rows = Math.floor(max_cells_to_show / num_cols)
+  const any_to_truncate = num_rows > num_truncated_rows
+  const [isTruncated, setTruncated] = useState(any_to_truncate)
+  const rows_to_show = isTruncated ? num_truncated_rows : num_rows
+
+  function TruncationToggle() {
+    if (!any_to_truncate) return null
+
+    return (
+      <a className="block text-center cursor-pointer" onClick={() => setTruncated(!isTruncated)}>
+        {isTruncated
+          ? `...and ${Math.ceil(num_rows - num_truncated_rows)} more rows.`
+          : `Truncate to < ${max_cells_to_show} total selections.`}
+      </a>
+    )
+  }
+
+  return { TruncationToggle, rows_to_show }
+}

--- a/src/trustee/decrypt/useTruncatedTable.tsx
+++ b/src/trustee/decrypt/useTruncatedTable.tsx
@@ -20,7 +20,7 @@ export const useTruncatedTable = ({
     if (!any_to_truncate) return null
 
     return (
-      <a className="block text-center cursor-pointer" onClick={() => setTruncated(!isTruncated)}>
+      <a className="block text-center opacity-50 cursor-pointer" onClick={() => setTruncated(!isTruncated)}>
         {isTruncated
           ? `...and ${Math.ceil(num_rows - num_truncated_rows)} more rows.`
           : `Truncate to < ${max_cells_to_show} total selections.`}

--- a/src/vote/useLocalStorage.ts
+++ b/src/vote/useLocalStorage.ts
@@ -8,7 +8,13 @@ export const useLocalStorageReducer = (
   defaultValue: ReducerParams[1],
 ) => {
   const stored = localStorage.getItem(storage_key)
-  const initial = stored ? JSON.parse(stored) : defaultValue
+  let initial
+  try {
+    initial = stored ? JSON.parse(stored) : defaultValue
+  } catch (error) {
+    alert(`Error parsing localStorage: ${storage_key} — ${JSON.stringify(error)}`)
+    throw error
+  }
   const [state, dispatch] = useReducer(reducer, initial)
 
   useEffect(() => {


### PR DESCRIPTION
NAP shuffle proof too big to stick in Firestore db. We only need this one for preliminary, non-official results, so need the ability to temp disable generating the shuffle proofs for now until we can properly fix for scale.

Remaining work before merging this:
- [ ] Make sure `Unlocking w/ shuffle proof` flow works
- [ ] Make sure `Unlocking skipping shuffle proof` flow works