### PR TITLE
Add support for Multi-Winner IRV Tallying

### DIFF
--- a/src/status/IRVTallies.tsx
+++ b/src/status/IRVTallies.tsx
@@ -13,10 +13,8 @@ export const IRVTallies = ({
   id: string
   results: ReturnType<typeof tally_IRV_Items>[string]
 }) => {
-  let winners = unTruncateSelection(results.winners[0], ballot_design, id)
-  for(let winnerIndex = 1; winnerIndex < results.winners.length; winnerIndex++) {
-    winners = winners + ', ' + unTruncateSelection(results.winners[winnerIndex], ballot_design, id)
-  }
+  const winners = results.winners.map((winner) => unTruncateSelection(winner, ballot_design, id)).join(', ')
+
   return (
     <div>
       {results.winners && (

--- a/src/status/IRVTallies.tsx
+++ b/src/status/IRVTallies.tsx
@@ -13,11 +13,15 @@ export const IRVTallies = ({
   id: string
   results: ReturnType<typeof tally_IRV_Items>[string]
 }) => {
+  let winners = unTruncateSelection(results.winners[0], ballot_design, id)
+  for(let winnerIndex = 1; winnerIndex < results.winners.length; winnerIndex++) {
+    winners = winners + ', ' + unTruncateSelection(results.winners[winnerIndex], ballot_design, id)
+  }
   return (
     <div>
-      {results.winner && (
+      {results.winners && (
         <div>
-          Winner: <b className="font-semibold">{unTruncateSelection(results.winner, ballot_design, id)}</b>{' '}
+          Winner{results.winners.length === 1 ? '' : 's'}: <b className="font-semibold">{winners}</b>{' '}
           <span className="text-xs opacity-50">
             (after {results.rounds.length} round
             {results.rounds.length === 1 ? '' : 's'})

--- a/src/status/tallying/rcv-irv.test.ts
+++ b/src/status/tallying/rcv-irv.test.ts
@@ -281,11 +281,11 @@ describe('MultiWinner RCV tallying', () => {
   const { rounds } = president
 
   test("can tally up everyone's top choices as round 1 votes", () => {
-    expect(rounds[0].tallies).toEqual({ 'Bill Clinton': 3, 'George H. W. Bu': 1, 'Abraham Lincoln': 1, 'Andrew Yang': 5 })
+    expect(rounds[0].tallies).toEqual({ 'Abraham Lincoln': 1, 'Andrew Yang': 5, 'Bill Clinton': 3, 'George H. W. Bu': 1 })
   })
 
   test('can eliminate first place winner, and recalculate round 2 votes', () => {
-    expect(rounds[1].tallies).toEqual({ 'Bill Clinton': 5, 'George H. W. Bu': 2, 'Ross Perot': 1, 'Abraham Lincoln': 2 })
+    expect(rounds[1].tallies).toEqual({ 'Abraham Lincoln': 2, 'Bill Clinton': 5, 'George H. W. Bu': 2, 'Ross Perot': 1 })
   })
 
   test('shows the correct number of rounds', () => {

--- a/src/status/tallying/rcv-irv.test.ts
+++ b/src/status/tallying/rcv-irv.test.ts
@@ -185,11 +185,11 @@ const sampleTwoWinnerVotes = {
     president: {
       id: 'president',
       multiple_votes_allowed: 4,
+      number_of_winners: 2,
       options: [{ name: 'George H. W. Bush' }, { name: 'Bill Clinton' }, { name: 'Ross Perot' }, {name: 'Abraham Lincoln'}, {name: 'Andrew Yang'}],
       title: 'Who should become President?',
       type: 'ranked-choice-irv',
-      write_in_allowed: false,
-      number_of_winners: 2
+      write_in_allowed: false
     },
   },
   votes: [

--- a/src/status/tallying/rcv-irv.test.ts
+++ b/src/status/tallying/rcv-irv.test.ts
@@ -186,10 +186,16 @@ const sampleTwoWinnerVotes = {
       id: 'president',
       multiple_votes_allowed: 4,
       number_of_winners: 2,
-      options: [{ name: 'George H. W. Bush' }, { name: 'Bill Clinton' }, { name: 'Ross Perot' }, {name: 'Abraham Lincoln'}, {name: 'Andrew Yang'}],
+      options: [
+        { name: 'George H. W. Bush' },
+        { name: 'Bill Clinton' },
+        { name: 'Ross Perot' },
+        { name: 'Abraham Lincoln' },
+        { name: 'Andrew Yang' },
+      ],
       title: 'Who should become President?',
       type: 'ranked-choice-irv',
-      write_in_allowed: false
+      write_in_allowed: false,
     },
   },
   votes: [
@@ -269,23 +275,25 @@ const sampleTwoWinnerVotes = {
 const rcv_mw_results = tallyVotes(sampleTwoWinnerVotes.ballot_items_by_id, sampleTwoWinnerVotes.votes)
 
 describe('MultiWinner RCV tallying', () => {
-  test('results now includes an IRV key', () => {
-    expect(rcv_mw_results).toHaveProperty('irv')
-  })
   const { president } = rcv_mw_results.irv
-
-  test('IRV items have a "rounds" subarray', () => {
-    expect(president).toHaveProperty('rounds')
-    expect(Array.isArray(president.rounds)).toBe(true)
-  })
   const { rounds } = president
 
   test("can tally up everyone's top choices as round 1 votes", () => {
-    expect(rounds[0].tallies).toEqual({ 'Abraham Lincoln': 1, 'Andrew Yang': 5, 'Bill Clinton': 3, 'George H. W. Bu': 1 })
+    expect(rounds[0].tallies).toEqual({
+      'Abraham Lincoln': 1,
+      'Andrew Yang': 5,
+      'Bill Clinton': 3,
+      'George H. W. Bu': 1,
+    })
   })
 
   test('can eliminate first place winner, and recalculate round 2 votes', () => {
-    expect(rounds[1].tallies).toEqual({ 'Abraham Lincoln': 2, 'Bill Clinton': 5, 'George H. W. Bu': 2, 'Ross Perot': 1 })
+    expect(rounds[1].tallies).toEqual({
+      'Abraham Lincoln': 2,
+      'Bill Clinton': 5,
+      'George H. W. Bu': 2,
+      'Ross Perot': 1,
+    })
   })
 
   test('shows the correct number of rounds', () => {

--- a/src/status/tallying/rcv-irv.test.ts
+++ b/src/status/tallying/rcv-irv.test.ts
@@ -74,7 +74,7 @@ describe('IRV tallying', () => {
   })
 
   test('can declare a single final winner', () => {
-    expect(president.winner).toEqual('Bill Clinton')
+    expect(president.winners[0]).toEqual('Bill Clinton')
   })
 
   test('can handle voters leaving blanks', () => {
@@ -138,8 +138,8 @@ describe('IRV tallying', () => {
       { president_1: 'Bill Clinton', tracking: '3333-3333-3333' },
       { president_1: 'Bill Clinton', tracking: '4444-4444-4444' },
     ])
-    const { rounds, winner } = results2.irv.president
-    expect(winner).toEqual('Bill Clinton')
+    const { rounds, winners } = results2.irv.president
+    expect(winners[0]).toEqual('Bill Clinton')
     expect(rounds.length).toEqual(1)
     expect(rounds[0].tallies).toEqual({ 'Bill Clinton': 4, 'George H. W. Bu': 2, 'Ross Perot': 1 })
   })
@@ -157,8 +157,8 @@ describe('IRV tallying', () => {
         tracking: '4444-4444-4444',
       },
     ])
-    const { rounds, winner } = results2.irv.president
-    expect(winner).toEqual('Bill Clinton')
+    const { rounds, winners } = results2.irv.president
+    expect(winners[0]).toEqual('Bill Clinton')
     expect(rounds.length).toEqual(3)
     expect(rounds[2].tallies).toEqual({ 'Abraham Lincoln': 4, 'Bill Clinton': 5 })
   })
@@ -169,4 +169,130 @@ describe('IRV tallying', () => {
   test.todo('handles when there is a tie in the top choice early on')
   test.todo('handles when there is a tie in the final round')
   test.todo('handles when there are a two digit number of multiple_votes_allowed')
+})
+
+// Multi-winner RCV Tallying tests
+// 10 votes total
+// threshold = 3.333
+// Yang - 4
+// Bill - 3
+// George - 2
+// Perot - 0
+// Lincoln - 1
+
+const sampleTwoWinnerVotes = {
+  ballot_items_by_id: {
+    president: {
+      id: 'president',
+      multiple_votes_allowed: 4,
+      options: [{ name: 'George H. W. Bush' }, { name: 'Bill Clinton' }, { name: 'Ross Perot' }, {name: 'Abraham Lincoln'}, {name: 'Andrew Yang'}],
+      title: 'Who should become President?',
+      type: 'ranked-choice-irv',
+      write_in_allowed: false,
+      number_of_winners: 2
+    },
+  },
+  votes: [
+    {
+      president_1: 'Bill Clinton',
+      president_2: 'George H. W. Bu',
+      president_3: 'Ross Perot',
+      president_4: 'Abraham Lincoln',
+      tracking: '3995-6836-1505',
+    },
+    {
+      president_1: 'Bill Clinton',
+      president_2: 'Ross Perot',
+      president_3: 'George H. W. Bu',
+      president_4: 'Abraham Lincoln',
+      tracking: '5225-1927-5026',
+    },
+    {
+      president_1: 'George H. W. Bu',
+      president_2: 'Bill Clinton',
+      president_3: 'Ross Perot',
+      president_4: 'Abraham Lincoln',
+      tracking: '5242-3203-2884',
+    },
+    {
+      president_1: 'Abraham Lincoln',
+      president_2: 'Bill Clinton',
+      president_3: 'Ross Perot',
+      president_4: 'George H. W. Bu',
+      tracking: '1234-5678-9012',
+    },
+    {
+      president_1: 'Bill Clinton',
+      president_2: 'Andrew Yang',
+      president_3: 'George H. W. Bu',
+      president_4: 'Abraham Lincoln',
+      tracking: '9876-5432-1098',
+    },
+    {
+      president_1: 'Andrew Yang',
+      president_2: 'Bill Clinton',
+      president_3: 'George H. W. Bu',
+      president_4: 'Abraham Lincoln',
+      tracking: '9876-5432-1097',
+    },
+    {
+      president_1: 'Andrew Yang',
+      president_2: 'Abraham Lincoln',
+      president_3: 'George H. W. Bu',
+      president_4: 'Ross Perot',
+      tracking: '9876-5432-1096',
+    },
+    {
+      president_1: 'Andrew Yang',
+      president_2: 'Bill Clinton',
+      president_3: 'George H. W. Bu',
+      president_4: 'Abraham Lincoln',
+      tracking: '9876-5432-1095',
+    },
+    {
+      president_1: 'Andrew Yang',
+      president_2: 'Ross Perot',
+      president_3: 'George H. W. Bu',
+      president_4: 'Abraham Lincoln',
+      tracking: '9876-5432-1094',
+    },
+    {
+      president_1: 'Andrew Yang',
+      president_2: 'George H. W. Bu',
+      president_3: 'Ross Perot',
+      president_4: 'Abraham Lincoln',
+      tracking: '9876-5432-1093',
+    },
+  ],
+}
+
+const rcv_mw_results = tallyVotes(sampleTwoWinnerVotes.ballot_items_by_id, sampleTwoWinnerVotes.votes)
+
+describe('MultiWinner RCV tallying', () => {
+  test('results now includes an IRV key', () => {
+    expect(rcv_mw_results).toHaveProperty('irv')
+  })
+  const { president } = rcv_mw_results.irv
+
+  test('IRV items have a "rounds" subarray', () => {
+    expect(president).toHaveProperty('rounds')
+    expect(Array.isArray(president.rounds)).toBe(true)
+  })
+  const { rounds } = president
+
+  test("can tally up everyone's top choices as round 1 votes", () => {
+    expect(rounds[0].tallies).toEqual({ 'Bill Clinton': 3, 'George H. W. Bu': 1, 'Abraham Lincoln': 1, 'Andrew Yang': 5 })
+  })
+
+  test('can eliminate first place winner, and recalculate round 2 votes', () => {
+    expect(rounds[1].tallies).toEqual({ 'Bill Clinton': 5, 'George H. W. Bu': 2, 'Ross Perot': 1, 'Abraham Lincoln': 2 })
+  })
+
+  test('shows the correct number of rounds', () => {
+    expect(rounds).toHaveLength(2)
+  })
+
+  test('can declare two final winners', () => {
+    expect(president.winners).toEqual(['Andrew Yang', 'Bill Clinton'])
+  })
 })

--- a/src/status/tallying/rcv-irv.ts
+++ b/src/status/tallying/rcv-irv.ts
@@ -61,28 +61,30 @@ export const tally_IRV_Items = (
 
       items[item].rounds.push(round_result)
 
-      // Did anyone exceed 50%?
-      const numberOfWinners = ballot_items_by_id[item].number_of_winners || 1
-      const fifty_percent = round_result.totalVotes / (numberOfWinners + 1)
-      let someoneEliminated = false
+      // Did anyone exceed the winning threshold? (50% for single-winner)
+      const { number_of_winners = 1 } = ballot_items_by_id[item]
+      const threshold_to_win = round_result.totalVotes / (number_of_winners + 1)
+
+      let eliminatedAWinner = false
       for (let currCandidateIndex = 0; currCandidateIndex < round_result.ordered.length; currCandidateIndex++) {
         const leader = round_result.ordered[currCandidateIndex]
-        if (round_result.tallies[leader] > fifty_percent) {
+        if (round_result.tallies[leader] > threshold_to_win) {
           // Yes! Found a winner
           items[item].winners.push(leader)
-          if(items[item].winners.length === numberOfWinners) {
-            return 
-          } else {
-            eliminated.push(leader)
-            someoneEliminated = true
-          }
+
+          // Done once found enough winners
+          if (items[item].winners.length === number_of_winners) return
+
+          // Remove winner from future rounds
+          eliminated.push(leader)
+          eliminatedAWinner = true
         }
       }
 
       // Otherwise, eliminate the lowest choice and restart the loop
       const last = round_result.ordered.at(-1)
       if (!last) return // shouldn't happen
-      if(!someoneEliminated) eliminated.push(last)
+      if (!eliminatedAWinner) eliminated.push(last)
     }
   })
 

--- a/src/vote/storeElectionInfo.ts
+++ b/src/vote/storeElectionInfo.ts
@@ -10,6 +10,7 @@ export type Item = {
   max_score?: number
   min_score?: number
   multiple_votes_allowed?: number
+  number_of_winners?: number
   options: {
     name: string
     sub?: string
@@ -24,7 +25,6 @@ export type Item = {
   toggleable_label?: string
   type?: string
   write_in_allowed: boolean
-  number_of_winners?: number
 }
 
 export function storeElectionInfo(dispatch: Dispatch<Partial<State>>, election_id?: string) {

--- a/src/vote/storeElectionInfo.ts
+++ b/src/vote/storeElectionInfo.ts
@@ -24,6 +24,7 @@ export type Item = {
   toggleable_label?: string
   type?: string
   write_in_allowed: boolean
+  number_of_winners?: number
 }
 
 export function storeElectionInfo(dispatch: Dispatch<Partial<State>>, election_id?: string) {


### PR DESCRIPTION
Goal is to extend the existing Ranked Choice ballot design for voters, but to adapt the tallying algorithm to support declaring multiple winners, not just a single one.

### Specific use-case:

There are 5 open nomination spots on the voting org's Executive Committee. 6 people have signed up as candidates.

The org's bylaws require all elections to use Ranked Choice Voting. Goal is to have voters fill out a single RCV ballot for the 6 candidates, but then be able to declare multiple winners.

### Current Level of SIV Support

SIV does support ranked choice voting, with a nice front-end UI for voters.

But currently, the only RCV tallying SIV supports is single-winner IRV (Hare algorithm — eliminate lowest until someone crosses 50%.).

This PR would extend that to multiple winners.

### Proportionality:

One unclear question is how important it is for the algorithm to respect Proportionality?

> Without Proportionality, you get 5 clones of someone 51% of people like, rather than 3 of them and 2 for the 49%.

## Must Do's before merging
- [x] unit tests for tallying algorithm
- [x] support to add `number_of_winners` to ballot schema in election-admin editor
  - [ ] nice-to-have: Document the new feature below the editor under "Advanced Features".
- [x] working tallying algorithm to calculate multiple winners
- [x] front-end support on Election Status page to display multiple winners