### PR TITLE
/admin/ballot-design: Banner once finalized, & Revert btn

### DIFF
--- a/pages/api/election/[election_id]/admin/finalize-ballot-design.ts
+++ b/pages/api/election/[election_id]/admin/finalize-ballot-design.ts
@@ -1,7 +1,6 @@
+import { firebase } from 'api/_services'
+import { checkJwtOwnsElection } from 'api/validate-admin-jwt'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-import { firebase } from '../../../_services'
-import { checkJwtOwnsElection } from '../../../validate-admin-jwt'
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { election_id } = req.query as { election_id: string }

--- a/pages/api/election/[election_id]/admin/revert-finalized-ballot-design.ts
+++ b/pages/api/election/[election_id]/admin/revert-finalized-ballot-design.ts
@@ -9,7 +9,12 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const jwt = await checkJwtOwnsElection(req, res, election_id)
   if (!jwt.valid) return
 
-  // TODO: Confirm there are no votes cast already
+  // Confirm no votes cast yet
+  if (jwt.num_votes > 0)
+    return res.status(400).json({
+      message: "Can't revert finalized ballot-design once any votes have been cast",
+      num_votes: jwt.num_votes,
+    })
 
   // TODO: We probably want better accountability here to be extra sure election admins aren't maliciously flipping ballot designs in misleading ways. See https://github.com/siv-org/siv/issues/85
 

--- a/pages/api/election/[election_id]/admin/revert-finalized-ballot-design.ts
+++ b/pages/api/election/[election_id]/admin/revert-finalized-ballot-design.ts
@@ -1,0 +1,24 @@
+import { firebase } from 'api/_services'
+import { checkJwtOwnsElection } from 'api/validate-admin-jwt'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { election_id } = req.query as { election_id: string }
+
+  // Confirm they're a valid admin that created this election
+  const jwt = await checkJwtOwnsElection(req, res, election_id)
+  if (!jwt.valid) return
+
+  // TODO: Confirm there are no votes cast already
+
+  // TODO: We probably want better accountability here to be extra sure election admins aren't maliciously flipping ballot designs in misleading ways. See https://github.com/siv-org/siv/issues/85
+
+  // TODO: Notify admin this feature is being used
+
+  // TODO: Store the previously- finalized version, to ensure this feature isn't being used maliciously
+
+  // Unset `ballot_design_finalized` in db
+  await firebase.firestore().collection('elections').doc(election_id).update({ ballot_design_finalized: false })
+
+  return res.status(201).json({ message: 'Reverted finalized ballot design' })
+}

--- a/pages/api/validate-admin-jwt.ts
+++ b/pages/api/validate-admin-jwt.ts
@@ -46,6 +46,7 @@ export async function checkJwtOwnsElection(
 ): Promise<
   | { res: void; valid: false }
   | ({
+      ballot_design: string
       ballot_design_finalized?: boolean
       election_manager: string
       election_title: string
@@ -68,6 +69,7 @@ export async function checkJwtOwnsElection(
 
   // Otherwise it passes
   return {
+    ballot_design: election.ballot_design,
     ballot_design_finalized: election.ballot_design_finalized,
     election_manager: election.election_manager,
     election_title: election.election_title,

--- a/pages/api/validate-admin-jwt.ts
+++ b/pages/api/validate-admin-jwt.ts
@@ -45,7 +45,13 @@ export async function checkJwtOwnsElection(
   election_id: string,
 ): Promise<
   | { res: void; valid: false }
-  | ({ ballot_design_finalized?: boolean; election_manager: string; election_title: string; valid: true } & JWT_Payload)
+  | ({
+      ballot_design_finalized?: boolean
+      election_manager: string
+      election_title: string
+      num_votes: number
+      valid: true
+    } & JWT_Payload)
 > {
   const jwt_status = checkJwt(req, res)
 
@@ -65,6 +71,7 @@ export async function checkJwtOwnsElection(
     ballot_design_finalized: election.ballot_design_finalized,
     election_manager: election.election_manager,
     election_title: election.election_title,
+    num_votes: election.num_votes,
     ...jwt_status,
   }
 }

--- a/src/admin/BallotDesign/BallotDesign.tsx
+++ b/src/admin/BallotDesign/BallotDesign.tsx
@@ -3,6 +3,7 @@ import { NoSsr } from 'src/_shared/NoSsr'
 
 import { useStored } from '../useStored'
 import { AutoSaver } from './AutoSaver'
+import { BallotDesignFinalizedBanner } from './BallotDesignFinalizedBanner'
 import { check_for_urgent_ballot_errors } from './check_for_ballot_errors'
 import { default_ballot_design } from './default-ballot-design'
 import { Errors } from './Errors'
@@ -49,6 +50,8 @@ export const BallotDesign = () => {
           🔍 Preview
         </a>
       </h2>
+
+      {ballot_design_finalized && <BallotDesignFinalizedBanner />}
 
       <AutoSaver {...{ design }} />
       <Errors {...{ error }} />

--- a/src/admin/BallotDesign/BallotDesignFinalizedBanner.tsx
+++ b/src/admin/BallotDesign/BallotDesignFinalizedBanner.tsx
@@ -1,0 +1,34 @@
+import { api } from 'src/api-helper'
+
+import { revalidate, useStored } from '../useStored'
+import { Tooltip } from '../Voters/Tooltip'
+
+export const BallotDesignFinalizedBanner = () => {
+  const { election_id, valid_voters } = useStored()
+  const has_votes = !!valid_voters?.filter((v) => v.has_voted).length
+
+  return (
+    <div className="flex items-center justify-between p-2 mb-5 border-2 border-solid rounded-lg border-green-700/50 bg-green-100/50">
+      <span>
+        The ballot design has been <i className="font-semibold">finalized</i>.
+      </span>
+
+      {/* 'Revert' button */}
+      {!has_votes && (
+        <Tooltip tooltip="Only possible before votes cast">
+          <div
+            className="inline px-2 py-1 border border-solid rounded cursor-pointer text-cyan-700 bg-white/70 border-black/30 hover:bg-white hover:text-cyan-600"
+            onClick={async () => {
+              const response = await api(`election/${election_id}/admin/revert-finalized-ballot-design`)
+              if (response.status !== 201) return alert(JSON.stringify(await response.json()))
+
+              revalidate(election_id)
+            }}
+          >
+            Revert
+          </div>
+        </Tooltip>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Preventing the sort of **_Misleadingly-Different-Ballot-Designs Attack_** described in https://github.com/siv-org/siv/issues/85 was one of the reasons election administrators using SIV have long needed to finalize their ballot designs before votes could be submitted.

### Problems:

1. It was easy to forget the ballot design was finalized, and weird that the designer UIs would then no-op with no explanation. 
2. Likewise, there have been many many innocent cases where the design was finalized prematurely, & voting hasn't begun yet anyway, and it's quite annoying to have to duplicate the election just to make minor tweaks.

## So now we're adding a new "Ballot Design Finalized" banner to the top of the page, with an additional `Revert` button too: 

<img width="541" alt="image" src="https://github.com/user-attachments/assets/a2ace3a5-370e-4030-8573-15a80712ec0e">


## Tooltip when hovering over the Revert button:

<img width="514" alt="image" src="https://github.com/user-attachments/assets/c689f769-3b84-4816-b934-70d926c32f7c">

## Revert button disappears once voting begins

<img width="514" alt="image" src="https://github.com/user-attachments/assets/4ab13392-eea6-4e25-bc77-6fdbf619c991">

- [x] The backend endpoint also checks to make sure no votes were cast yet. [`957091a` (#251)](https://github.com/siv-org/siv/pull/251/commits/957091a50b10fa43b30f7804047980c5f26d7968)

## Possible attack?

As currently implemented, this still leaves open a small window where the admin could send the voting interface to a subset of voters, who would download the ballot design (happens as soon as the page loads)— but *then* the admin could Un-finalize and switch the intent of the ballot, before any votes are actually cast. That's a very small window of attack: after voting page loaded, but before vote submission. Hard, but not impossible.

- Note in this case the malicious party is the human election admin using SIV, not the SIV infrastructure itself (a different threat model to still work to improve against too..., see https://github.com/siv-org/siv/issues/85 for more) 

### So some solutions to mitigate this:


- [ ] hash the ballot design, and check what's changed between versions, as described in https://github.com/siv-org/siv/issues/85
- [ ] have the voter include the ballot design they're voting from when they submit their vote, and include that in their emailed submission receipt

### Short-term solution to not block shipping this feature

- [x] track each of these "finalized" ballot states better [`38ad85a` (#251)](https://github.com/siv-org/siv/pull/251/commits/38ad85a17e9a85ae945e6a869abcb7485f23cfac)
- [x] Priority logging & notifications on this `revert-finalized-ballot-design` feature, so we can catch any possibly malicious cases if they come up [`38ad85a` (#251)](https://github.com/siv-org/siv/pull/251/commits/38ad85a17e9a85ae945e6a869abcb7485f23cfac)
