### PR TITLE
Print /add-trustees error message to screen

### DIFF
--- a/src/admin/PrivacyPage/SetPrivacyProtectors.tsx
+++ b/src/admin/PrivacyPage/SetPrivacyProtectors.tsx
@@ -135,6 +135,7 @@ export const SetPrivacyProtectors = () => {
               if (response.status === 201) {
                 revalidate(election_id)
               } else {
+                alert(JSON.stringify(await response.json()))
                 throw await response.json()
               }
             }}


### PR DESCRIPTION
If there was a server error when calling `/api/add-trustees` (including "Skip"), the error message would be thrown and visible if dug into the browser console, but not the UI itself. 

This PR makes it easier by also printing it to the UI, so the admin doesn't need to go hunting for it.

<img width="591" alt="image" src="https://github.com/user-attachments/assets/71b3f03b-19b0-4826-b21e-47116c39f6d4">
