### PR TITLE
Add PUSHER_APP_ID to .env.local.TEMPLATE

### DIFF
--- a/.env.local.TEMPLATE
+++ b/.env.local.TEMPLATE
@@ -21,6 +21,7 @@ MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
 
 # Pusher - https://pusher.com - real-time updates via websocket channels
+PUSHER_APP_ID=
 PUSHER_KEY=
 PUSHER_SECRET=
 


### PR DESCRIPTION
This is another .env that most people are going to want. The code defaults to using SIV (since it's not secret), but other people's PUSHER_KEY and PUSHER_SECRET will be incompatible, and almost certainly want to override the default:

https://github.com/siv-org/siv/blob/93eb2be448cc4e43fdeec5a134c6d25cf19e8054/pages/api/pusher.ts#L4-L8