### PR TITLE
Updated /crypto/ unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siv-web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "patch-package",
     "lint": "eslint src/ pages/",
     "start": "next start",
-    "test": "yarn lint && yarn typecheck && yarn e2e",
+    "test": "bun lint && bun typecheck && bun unit && bun e2e",
     "test:crypto": "bun test src/crypto/tests/*.test.ts",
     "typecheck": "tsc --pretty --noEmit",
     "unit": "bun test src"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint src/ pages/",
     "start": "next start",
     "test": "yarn lint && yarn typecheck && yarn e2e",
+    "test:crypto": "bun test src/crypto/tests/*.test.ts",
     "typecheck": "tsc --pretty --noEmit",
     "unit": "bun test src"
   },
@@ -88,11 +89,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",
-    "@types/bun": "^1.0.8",
+    "@types/bun": "^1.2.13",
     "@types/cookies": "^0.7.6",
     "@types/jsonwebtoken": "^8.5.1",
     "@types/mailgun-js": "^0.22.10",
-    "@types/node": "^13.9.5",
+    "@types/node": "^22",
     "@types/react-linkify": "^1.0.4",
     "@types/react-scroll": "^1.8.2",
     "@types/smoothscroll-polyfill": "^0.3.1",

--- a/src/crypto/bigint-from-seed.ts
+++ b/src/crypto/bigint-from-seed.ts
@@ -1,53 +1,27 @@
 import { CURVE } from '@noble/ed25519'
 
 import { bytesToHex } from './bytes-to-hex'
-import { mod } from './curve'
 import { sha256 } from './sha256'
 
-/**
- * Deterministically generate a pseudorandom bigint less than `max`, from a given `seed` string.
- */
+/** Deterministically generates a pseudorandom bigint less than `max`, from a seed string. */
 export async function bigint_from_seed(seed: string, max = CURVE.l): Promise<bigint> {
-  // This will hold our growing buffer of bytes
-  let bytes = new ArrayBuffer(0)
+  /* This is intended for use in Fiat–Shamir transformations or deterministic PRNGs.
+  It uses rejection sampling to avoid mod-bias.
 
-  // How many bytes will we need?
-  const bits = max.toString(2).length
-  const bytesNeeded = Math.ceil(bits / 8)
+  @param seed - Any string input to bind the randomness to context (e.g., 'proof_type,input1,input2')
+  @param max - The upper bound (exclusive) for the output bigint. Defaults to the Ed25519 curve order.
+  @returns A bigint uniformly sampled in [0, max) */
 
-  // Because we're going to mod the result, we want to create significantly more bytes
-  // than necessary, so that the overlap bias becomes insignificant
-  const antibias_amount = 10
+  const maxBits = max.toString(2).length
+  const bytesNeeded = Math.ceil(maxBits / 8)
 
-  // 1. Get enough bits
-  while (bytes.byteLength < bytesNeeded + antibias_amount) {
+  while (true) {
     const hash = await sha256(seed)
-    seed = [...new Uint8Array(hash)].join(',')
-    bytes = appendBuffer(bytes, hash)
+    const hex = bytesToHex(new Uint8Array(hash)).slice(0, bytesNeeded * 2)
+    const x = BigInt(`0x${hex}`)
+    if (x < max) return x
+
+    // Retry deterministically by feeding hash back in
+    seed = hex
   }
-
-  // 2. Convert bits into a BigInt
-  const hex = `0x${bytesToHex(bytes)}`
-  const integer = BigInt(hex)
-
-  // 3. Make sure integer is not greater than max
-  const result = mod(integer, max)
-
-  return result
-}
-
-/**
- * Creates a new Uint8Array based on two different ArrayBuffers
- *
- * @param buffer1 The first buffer.
- * @param buffer2 The second buffer.
- * @return The new ArrayBuffer created out of the two.
- *
- * from: https://gist.github.com/72lions/4528834
- */
-function appendBuffer(buffer1: ArrayBuffer, buffer2: ArrayBuffer) {
-  const temporary = new Uint8Array(buffer1.byteLength + buffer2.byteLength)
-  temporary.set(new Uint8Array(buffer1), 0)
-  temporary.set(new Uint8Array(buffer2), buffer1.byteLength)
-  return temporary.buffer as ArrayBuffer
 }

--- a/src/crypto/shuffle-proof.ts
+++ b/src/crypto/shuffle-proof.ts
@@ -320,7 +320,7 @@ async function verify_simple_shuffle_proof({ alphas, Gamma, Thetas, Xs, Ys }: Si
 }
 
 // Fiat-Shamir deterministic PRNG challenge integers
-const hash = (args: RP[]) => bigint_from_seed(args.join(','))
+const hash = (args: RP[]) => bigint_from_seed(['shuffle_proof', ...args].join(','))
 const prng = {
   c: (Thetas: RP[]) => hash(Thetas),
   lambda: (Ds: RP[]) => hash(Ds),

--- a/src/crypto/tests/bigint-from-seed.test.ts
+++ b/src/crypto/tests/bigint-from-seed.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'bun:test'
+import { range } from 'lodash'
+
+import { bigint_from_seed } from '../bigint-from-seed'
+import { CURVE } from '../curve'
+
+test('Deterministically generate a pseudorandom integer less than `max`, from a given `seed` string.', async () => {
+  // Make multiple versions
+  const bigints = await Promise.all(range(5).map(() => bigint_from_seed('foobar')))
+
+  // Between zero & max (zero inclusive)
+  expect(bigints[0]).toBeGreaterThanOrEqual(BigInt(0))
+  expect(bigints[0]).toBeLessThan(CURVE.l)
+
+  // Determinism: Test all are the same value
+  bigints.forEach((b) => {
+    expect(b).toBe(bigints[0])
+  })
+})

--- a/src/crypto/tests/bigint-from-seed.test.ts
+++ b/src/crypto/tests/bigint-from-seed.test.ts
@@ -21,11 +21,18 @@ test('Deterministically generate a pseudorandom integer less than `max`, from a 
 test("RPs implicitly cast .toHex() when .join()'d", () => {
   // If this breaks, Fiat-Shamir PRNGs could lose soundness, letting in invalid proofs.
   // So we explicitly test for it, to protect against future library updates or similar.
-
   const point = G.multiply(BigInt(12345))
 
   const explicitHex = point.toHex()
   const joined = [point, point].join(',')
 
   expect(joined).toBe(`${explicitHex},${explicitHex}`)
+})
+
+test('RP.toString() is stable and canonical', () => {
+  // This test warns against changes in RP.toString(),
+  // which would invalidate existing Fiat–Shamir proofs.
+  const point = G.multiply(BigInt(12345))
+  const expected = 'b4c1b3cdef7ba1bd94fa95c7b736622046ef663285813c2293c52c5f4f9fb011'
+  expect(point.toString()).toBe(expected)
 })

--- a/src/crypto/tests/bigint-from-seed.test.ts
+++ b/src/crypto/tests/bigint-from-seed.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test'
 import { range } from 'lodash'
 
 import { bigint_from_seed } from '../bigint-from-seed'
-import { CURVE } from '../curve'
+import { CURVE, G } from '../curve'
 
 test('Deterministically generate a pseudorandom integer less than `max`, from a given `seed` string.', async () => {
   // Make multiple versions
@@ -16,4 +16,16 @@ test('Deterministically generate a pseudorandom integer less than `max`, from a 
   bigints.forEach((b) => {
     expect(b).toBe(bigints[0])
   })
+})
+
+test("RPs implicitly cast .toHex() when .join()'d", () => {
+  // If this breaks, Fiat-Shamir PRNGs could lose soundness, letting in invalid proofs.
+  // So we explicitly test for it, to protect against future library updates or similar.
+
+  const point = G.multiply(BigInt(12345))
+
+  const explicitHex = point.toHex()
+  const joined = [point, point].join(',')
+
+  expect(joined).toBe(`${explicitHex},${explicitHex}`)
 })

--- a/src/crypto/tests/lagrange.test.ts
+++ b/src/crypto/tests/lagrange.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test'
+
+import { lagrange_interpolation, moduloLambda } from '../lagrange'
+
+// Example from https://babyphd.net/2016/03/introduction-to-threshold-signature-scheme/
+// 2.2. Shamir’s Secret Sharing Scheme and Lagrange Coefficient
+
+// Shamir’s threshold (3,4) over Z_7:
+const modulo = BigInt(7)
+
+// Distribution: Dealer has secret s=4
+const secret = 4
+
+// and picks a1 = 2, a2 = 5. Hence, polynomial P(x) = 4 + 2x + 5x ^ 2(mod 7).
+
+type Point = [bigint, bigint]
+
+// Dealer sends s1=4 to P1, s2=0 to P2, s3=6 to P1, s4=1 to P4.
+const points: Point[] = (
+  [
+    [1, 4],
+    [2, 0],
+    [3, 6],
+    [4, 1],
+  ] as [number, number][]
+).map((point) => point.map(BigInt) as Point)
+
+// Reconstruction: When P1, P3 and P4 come together,
+// we have s = 4
+const points_used: Point[] = [points[0], points[2], points[3]]
+
+test('can calculate individual modLambda products', () => {
+  // 2nd lambda product (as given in example:)
+  // = 1/(1-3) * 4/(4-3) % 7
+  // = 2^(-1) * 4    % 7
+  // = 4 * 4         % 7
+  // = 16            % 7
+  // = 2
+
+  // But example is wrong on 2nd line...
+  // should be (-2)^(-1), not positive 2^(-1).
+  // = 1/(1-3)   * 4/(4-3) % 7
+  // = (-2)^(-1) * 4 % 7
+  // =    5^(-1) * 4 % 7
+  // =        3  * 4 % 7
+  // =            12 % 7
+  // = 5
+  expect(moduloLambda(1, points_used, modulo).toString()).toBe('5')
+  // (moduloLambda is 0-indexed, so index=1 is the 2nd term)
+
+  // 3rd lambda product (as given in example):
+  // = 1/(1-4) * 3/(3-4) % 7
+  // =  4^(-1) *  3^(-1) % 7
+  // =      2  *      5  % 7
+  // =               10  % 7
+  // = 3
+
+  // But example is again wrong on 2nd line...
+  // 2nd term denominator is -1, ~= 6
+  // = 1/(1-4)   * 3/(3-4)    % 7
+  // = (-3)^(-1) * 3/(-1)     % 7
+  // =   4 ^(-1) * 3/6        % 7
+  // =        2  * 3*(6^(-1)) % 7
+  // =        2  * 3*     6   % 7
+  // =                   36   % 7
+  // = 1
+  expect(moduloLambda(2, points_used, modulo).toString()).toBe('1')
+})
+
+test('can find constant using lagrange interpolation', () => {
+  expect(lagrange_interpolation(points_used, modulo).toString()).toBe(String(secret))
+})

--- a/src/crypto/tests/pick-random-bigint.test.ts
+++ b/src/crypto/tests/pick-random-bigint.test.ts
@@ -4,58 +4,70 @@ import { orderBy } from 'lodash'
 import { CURVE, random_bigint } from '../curve'
 import { pick_random_bigint } from '../pick-random-bigint'
 
-test('Can generate a secret key for voter, using secure source of randomness', () => {
+test('generates a number between 0 and max', () => {
+  const max = BigInt(100)
+  const random = pick_random_bigint(max)
+
+  expect(random).toBeGreaterThan(BigInt(0))
+  expect(random).toBeLessThan(max)
+})
+
+test('generates a valid secret key for voter using secure source of randomness', () => {
   const secret = random_bigint()
 
-  // Between zero & modulo
   expect(secret).toBeGreaterThan(BigInt(0))
   expect(secret).toBeLessThan(CURVE.l)
 })
 
-test('Evenly distributed', () => {
-  // Test many cases
-  const bits = 10
-  const max = 2 ** bits
-  // for (let max = 1000; max < 1050; max += 1) {
+test('handles edge cases correctly', () => {
+  // Test with small max
+  const smallMax = BigInt(2)
+  const smallRandom = pick_random_bigint(smallMax)
+  expect(smallRandom).toBe(BigInt(1))
+
+  // Test with large max
+  const largeMax = BigInt(2) ** BigInt(256)
+  const largeRandom = pick_random_bigint(largeMax)
+  expect(largeRandom).toBeGreaterThan(BigInt(0))
+  expect(largeRandom).toBeLessThan(largeMax)
+})
+
+const max = 2 ** 16
+test(`generates evenly distributed numbers (n=${max})`, () => {
   const hits: { [index: string]: number } = {}
-  for (let i = 0; i < max; i += 1) {
+  const numSamples = max
+
+  // Generate samples
+  for (let i = 0; i < numSamples; i += 1) {
     const random = pick_random_bigint(BigInt(max))
-
-    // Greater than zero
     expect(random).toBeGreaterThan(BigInt(0))
-
-    // Less than max
     expect(random).toBeLessThan(BigInt(max))
 
     const asString = random.toString()
-
     hits[asString] = (hits[asString] || 0) + 1
   }
 
+  // Analyze distribution
   const uniqueHits = Object.keys(hits)
-
-  // List most common collisions
   const uniqueHitsTuples = uniqueHits.map((h) => ({
     hits: hits[h],
     num: h,
   }))
   const sorted = orderBy(uniqueHitsTuples, 'hits', 'desc')
-  // console.log('Top hits:', sorted.slice(0, 5))
-  // Expect no random numbers to have collided more than a few times
-  expect(sorted[0].hits).toBeLessThan(10)
 
-  // Expect number of unique entries to be within 40% of max
+  // Test distribution properties
+  const maxHits = sorted[0].hits
   const numberUniques = uniqueHits.length
   const diff = (max - numberUniques) / max
-  // const diffPercent = Math.floor(diff * 1000) / 10
-  // console.log({
-  //   bits,
-  //   diffPercent,
-  //   max,
-  //   numberUniques,
-  // })
+
+  // No number should appear significantly more often than others
+  expect(maxHits).toBeLessThan(Math.cbrt(max))
+
+  // Should have good coverage of the range
   expect(diff).toBeLessThan(0.4)
-  // }
+
+  // Should have reasonable number of unique values
+  expect(numberUniques).toBeGreaterThan(max * 0.6)
 })
 
 // test.todo('Test with dieharder suite https://formulae.brew.sh/formula/dieharder')

--- a/src/crypto/tests/pick-random-bigint.test.ts
+++ b/src/crypto/tests/pick-random-bigint.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'bun:test'
+import { orderBy } from 'lodash'
+
+import { CURVE, random_bigint } from '../curve'
+import { pick_random_bigint } from '../pick-random-bigint'
+
+test('Can generate a secret key for voter, using secure source of randomness', () => {
+  const secret = random_bigint()
+
+  // Between zero & modulo
+  expect(secret).toBeGreaterThan(BigInt(0))
+  expect(secret).toBeLessThan(CURVE.l)
+})
+
+test('Evenly distributed', () => {
+  // Test many cases
+  const bits = 10
+  const max = 2 ** bits
+  // for (let max = 1000; max < 1050; max += 1) {
+  const hits: { [index: string]: number } = {}
+  for (let i = 0; i < max; i += 1) {
+    const random = pick_random_bigint(BigInt(max))
+
+    // Greater than zero
+    expect(random).toBeGreaterThan(BigInt(0))
+
+    // Less than max
+    expect(random).toBeLessThan(BigInt(max))
+
+    const asString = random.toString()
+
+    hits[asString] = (hits[asString] || 0) + 1
+  }
+
+  const uniqueHits = Object.keys(hits)
+
+  // List most common collisions
+  const uniqueHitsTuples = uniqueHits.map((h) => ({
+    hits: hits[h],
+    num: h,
+  }))
+  const sorted = orderBy(uniqueHitsTuples, 'hits', 'desc')
+  // console.log('Top hits:', sorted.slice(0, 5))
+  // Expect no random numbers to have collided more than a few times
+  expect(sorted[0].hits).toBeLessThan(10)
+
+  // Expect number of unique entries to be within 40% of max
+  const numberUniques = uniqueHits.length
+  const diff = (max - numberUniques) / max
+  // const diffPercent = Math.floor(diff * 1000) / 10
+  // console.log({
+  //   bits,
+  //   diffPercent,
+  //   max,
+  //   numberUniques,
+  // })
+  expect(diff).toBeLessThan(0.4)
+  // }
+})
+
+// test.todo('Test with dieharder suite https://formulae.brew.sh/formula/dieharder')

--- a/src/crypto/tests/shuffle-proof.test.ts
+++ b/src/crypto/tests/shuffle-proof.test.ts
@@ -1,0 +1,75 @@
+import bluebird from 'bluebird'
+import { expect, test } from 'bun:test'
+
+import { G, random_bigint, stringToPoint } from '../curve'
+import { generate_key_pair } from '../generate-key-pair'
+import { pick_random_bigint } from '../pick-random-bigint'
+import { generate_shuffle_proof, verify_shuffle_proof } from '../shuffle-proof'
+
+test('Can Verifiably Shuffle (permute & re-encrypt) a list of votes', async () => {
+  const num_votes = 5
+
+  const k = num_votes
+
+  const num_tests = 10
+  // console.log(`Trying proof ${num_tests} times`)
+  let num_passed = 0
+
+  await bluebird.map(
+    new Array(num_tests).fill(''),
+    async () => {
+      // Election keypair
+      const { public_key } = generate_key_pair()
+
+      // Generate ElGamal pairs for testing
+      const inputs = [...new Array(k).keys()].map(() => {
+        const randomizer = random_bigint()
+        const m = pick_random_bigint(BigInt(10 ** 8))
+        const message = stringToPoint(m.toString())
+
+        // Calculate our encrypted message
+        const shared_secret = public_key.multiply(randomizer)
+        const encrypted = message.add(shared_secret)
+
+        // This unlock factor lets someone with the decryption key reverse the encryption
+        const lock = G.multiply(randomizer)
+
+        return {
+          c1: lock,
+          c2: encrypted,
+        }
+      })
+
+      // Build permutation array
+      const pi: number[] = []
+      const options = [...new Array(k).keys()]
+      while (options.length) {
+        const i = Math.floor(Math.random() * options.length)
+        pi.push(options.splice(i, 1)[0])
+      }
+      // console.log(`pi = ${pi}`)
+
+      const reencryption_array = inputs.map(() => random_bigint())
+
+      // Create shuffled list
+      const outputs: typeof inputs = []
+      for (let i = 0; i < k; i += 1) {
+        const r = reencryption_array[pi[i]]
+        outputs.push({
+          c1: inputs[pi[i]].c1.add(G.multiply(r)),
+          c2: inputs[pi[i]].c2.add(public_key.multiply(r)),
+        })
+      }
+
+      let good = false
+      const proof = await generate_shuffle_proof(inputs, outputs, reencryption_array, pi, public_key)
+      good = await verify_shuffle_proof(inputs, outputs, proof)
+
+      if (good) num_passed += 1
+
+      // console.log(`${num_passed} passed of ${test_num}`, num_passed / test_num)
+    },
+    { concurrency: 1 },
+  )
+  expect(num_passed, 'Invalid shuffle proof').toBe(num_tests)
+})

--- a/src/crypto/tests/shuffle.test.ts
+++ b/src/crypto/tests/shuffle.test.ts
@@ -1,0 +1,75 @@
+import bluebird from 'bluebird'
+import { expect, test } from 'bun:test'
+import { isEqual, range } from 'lodash'
+
+import { pointToString, random_bigint, stringToPoint } from '../curve'
+import decrypt from '../decrypt'
+import encrypt from '../encrypt'
+import { generate_key_pair } from '../generate-key-pair'
+import { rename_to_c1_and_2, shuffleWithProof } from '../shuffle'
+import { verify_shuffle_proof } from '../shuffle-proof'
+
+test('Can Verifiably Shuffle (permute & re-encrypt) a list of votes, with valid proof', async () => {
+  const num_tests = 1
+  let num_passed = 0
+  let num_ran = 0
+  await bluebird.map(
+    new Array(num_tests).fill(''),
+    async () => {
+      const sample_size = 5
+      const { decryption_key, public_key } = generate_key_pair()
+
+      const plaintexts = range(sample_size).map((_, index) => `${'ABCDE'.split('')[index]}`)
+      // console.log({ plaintexts })
+
+      const encrypted_votes = plaintexts.map((plaintext) =>
+        encrypt(public_key, random_bigint(), stringToPoint(plaintext)),
+      )
+      // console.log('encrypted_votes:', encrypted_votes.map(toStrings))
+
+      // Shuffle votes
+      const { proof, shuffled } = await shuffleWithProof(public_key, encrypted_votes)
+      // console.log('shuffled:', shuffled.map(toStrings))
+
+      // Expect none of the previous ciphertexts are in the newly shuffled list
+      shuffled.forEach((cipher) => {
+        expect(
+          encrypted_votes.some((unshuffled) => isEqual(cipher, unshuffled)),
+          `${cipher} found in previous list`,
+        ).toBe(false)
+      })
+
+      // Decrypt the votes
+      const decrypteds = shuffled.map((cipher) => {
+        const decrypted = decrypt(decryption_key, cipher)
+        // console.log({ decrypted })
+
+        const decoded = pointToString(decrypted)
+        // console.log({ decoded })
+        return decoded
+      })
+
+      // Expect all our original messages to be in there
+      decrypteds.forEach((decrypted) => {
+        expect(plaintexts.includes(decrypted), `${decrypted} wasn't in original plaintexts`).toBe(true)
+      })
+
+      // Expect the list to have been permuted.
+      //   We can check if at least one of the decrypted values
+      //   is different from the original plaintext at same index
+      //   ( There's a 1 / 5! chance (1/120) this will fail by chance )
+      expect(decrypteds.some((decrypted, index) => decrypted !== plaintexts[index])).toBe(true)
+
+      // Expect the proof to verify true
+      const good = await verify_shuffle_proof(rename_to_c1_and_2(encrypted_votes), rename_to_c1_and_2(shuffled), proof)
+      num_ran += 1
+      if (good) num_passed += 1
+      // console.log({ good, num_passed, num_ran })
+    },
+    { concurrency: 1 },
+  )
+
+  expect(num_passed, 'Shuffle proofs did not all verify').toBe(num_ran)
+
+  // console.log({ num_passed })
+})

--- a/src/crypto/tests/threshold-keygen.test.ts
+++ b/src/crypto/tests/threshold-keygen.test.ts
@@ -1,0 +1,190 @@
+import { expect, test } from 'bun:test'
+import { mapValues, noop } from 'lodash'
+
+import { CURVE, G, random_bigint, RP, stringToPoint } from '../curve'
+import decrypt from '../decrypt'
+import encrypt from '../encrypt'
+import {
+  combine_partials,
+  compute_keyshare,
+  compute_pub_key,
+  evaluate_private_polynomial,
+  generate_public_coefficients,
+  is_received_share_valid,
+  partial_decrypt,
+  pick_private_coefficients,
+  unlock_message_with_shared_secret,
+} from '../threshold-keygen'
+
+// This type will accumulate data throughout this script
+type Trustee = {
+  broadcast: RP[]
+  keyshare?: bigint
+  name: string
+  private_coefficients: bigint[]
+  secrets_from: { [index: string]: bigint }
+  verified: { [index: string]: boolean }
+}
+
+// // Debug functions
+let step_counter = 1
+// const { log } = console
+const log = noop // console
+
+const log_step = (step: string) => log(`\n${step_counter++}.`, step)
+
+// Convert Bigs to strings
+const toString = (trustees: Trustee[]) =>
+  trustees.map((p) =>
+    mapValues(p, (value, key) => {
+      switch (key) {
+        case 'keyshare':
+          return p.keyshare?.toString()
+        case 'private_coefficients':
+          return p.private_coefficients?.map((c) => c.toString())
+        case 'secrets_from':
+          return mapValues(p.secrets_from, (s) => s.toString())
+        default:
+          return value
+      }
+    }),
+  )
+
+log('Testing the distributed threshold key generation protocol...')
+
+log_step('Admin announces trustees')
+const trustees: Trustee[] = 'ABC'
+  .split('')
+  .map((name) => ({ broadcast: [], name, private_coefficients: [], secrets_from: {}, verified: {} }))
+log(trustees)
+
+log_step('Each trustee picks their own private coefficients in Z[l]')
+trustees.forEach((_, index) => {
+  trustees[index].private_coefficients = pick_private_coefficients(trustees.length)
+})
+test('can pick random private coefficients', () => {
+  toString(trustees).forEach((trustee) => {
+    const coefficients = trustee.private_coefficients as bigint[]
+
+    expect(coefficients.length, 'Coefficients are the right length').toBe(trustees.length)
+    expect(new Set(coefficients).size, 'Coefficients are distinct').toBe(coefficients.length)
+  })
+})
+log(toString(trustees))
+
+log_step('Each trustee generates broadcast values')
+trustees.forEach(({ private_coefficients }, index) => {
+  trustees[index].broadcast = generate_public_coefficients(private_coefficients)
+})
+test('can generate broadcasts proofs', () => {
+  trustees.forEach(({ broadcast }) => {
+    expect(broadcast.length, 'Broadcast is the right length').toBe(trustees.length)
+  })
+})
+log(toString(trustees))
+
+log_step('Each trustee calculates shares to send to others')
+trustees.forEach(({ name, private_coefficients }) => {
+  trustees.forEach((_, toIndex) => {
+    // Initialize empty object if needed
+    if (!trustees[toIndex].secrets_from) {
+      trustees[toIndex].secrets_from = {}
+    }
+
+    trustees[toIndex].secrets_from[name] = evaluate_private_polynomial(toIndex + 1, private_coefficients)
+  })
+})
+test('can calculate pairwise shares', () => {
+  trustees.forEach(({ secrets_from }) => {
+    expect(Object.keys(secrets_from).length, 'Shares are the right length').toBe(trustees.length)
+  })
+})
+log(toString(trustees))
+
+log_step('Each trustee can verify their received shares')
+trustees.forEach(({ secrets_from }, jIndex) => {
+  trustees.forEach(({ broadcast, name }) => {
+    // Initialize empty object if needed
+    if (!trustees[jIndex].verified) {
+      trustees[jIndex].verified = {}
+    }
+
+    trustees[jIndex].verified[name] = is_received_share_valid(
+      secrets_from[name],
+      jIndex + 1,
+
+      broadcast,
+    )
+  })
+})
+test('All trustees verify all received shares', () => {
+  trustees.forEach(({ name, verified }) => {
+    const verifications = Object.keys(verified)
+
+    expect(verifications.length, 'Verifications are the right length').toBe(trustees.length)
+    verifications.forEach((verification) =>
+      expect(verified[verification], `${name} couldn't verify ${verification}`).toBe(true),
+    )
+  })
+})
+// log(toString(trustees))
+
+log_step('Each trustee calculates own keyshare from incoming secrets')
+trustees.forEach(({ secrets_from }, index) => {
+  trustees[index].keyshare = compute_keyshare(Object.values(secrets_from))
+})
+test('can calculate own keyshare from incoming secrets', () => {
+  trustees.forEach((trustee) => {
+    expect(typeof trustee.keyshare, 'Keyshare is bigint').toBe('bigint')
+    expect(trustee.keyshare, 'Keyshare is less than l').toBeLessThan(CURVE.l)
+  })
+})
+log(toString(trustees))
+
+log_step('Anyone can calculate the generated pub key from broadcasts')
+const first_broadcasts = trustees.map((trustee) => trustee.broadcast[0])
+const pub_key = compute_pub_key(first_broadcasts)
+
+// In a real setting no one ever gets the full secret
+// but we can test it against pub_key here.
+const private_constants = trustees.map((trustee) => trustee.private_coefficients[0])
+const full_private_key = compute_keyshare(private_constants)
+log({ full_private_key: full_private_key.toString() })
+test('Anyone can calculate the generated pub key from broadcasts', () => {
+  expect(pub_key.toString(), 'MPC pub key matches expected').toBe(G.multiply(full_private_key).toString())
+})
+log({ pub_key: pub_key.toString() })
+
+log_step('Given a ciphertext encrypted to pub_key, each trustee can partially decrypt')
+const plaintext = 'D'
+log({ plaintext })
+const encoded = stringToPoint(plaintext)
+test('encoded to a point successfully', () => {
+  expect(encoded, 'encoded is a point').toBeInstanceOf(RP)
+})
+log({ encoded })
+const encrypted = encrypt(pub_key, random_bigint(), encoded)
+log({ encrypted })
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const partials = trustees.map((trustee) => partial_decrypt(encrypted.lock, trustee.keyshare!))
+test('Each trustee can partially decrypt', () => {
+  partials.forEach((partial) => expect(partial, 'partial is RP').toBeInstanceOf(RP))
+})
+log({ partials })
+
+log_step('partials can be combined into the shared secret')
+const shared_secret = combine_partials(partials)
+log({ shared_secret })
+const decryptedTogether = unlock_message_with_shared_secret(shared_secret, encrypted.encrypted)
+log({ decryptedTogether })
+
+const decryptedAlone = decrypt(full_private_key, encrypted)
+log({ decryptedAlone })
+
+// const decoded = decode(decryptedTogether)
+// log({ decoded })
+
+test('Decrypted message matches encoded', () => {
+  expect(decryptedTogether.toHex(), 'decryptedTogether matches encoded').toBe(encoded.toHex())
+  expect(decryptedTogether.toHex(), 'decryptedTogether matches decryptedAlone').toBe(decryptedAlone.toHex())
+})

--- a/src/crypto/threshold-keygen.ts
+++ b/src/crypto/threshold-keygen.ts
@@ -148,18 +148,22 @@ export async function generate_partial_decryption_proof(cipher_lock: RP, trustee
 
   const g_to_trustees_keyshare = G.multiply(trustees_secret)
 
-  // Calculates Verifier's deterministic random number (Fiat-Shamir technique):
-  const public_r = await bigint_from_seed(`${cipher_lock} ${g_to_trustees_keyshare}`)
-
-  // Prover creates and sends:
-  const O = mod(secret_r + public_r * trustees_secret)
-
   // Prover also shares commitment of their secret randomizer choice
   const R = G.multiply(secret_r)
   const LR = cipher_lock.multiply(secret_r)
 
+  // Calculates Verifier's deterministic random number (Fiat-Shamir technique):
+  const public_r = await prngR(cipher_lock, g_to_trustees_keyshare, R, LR)
+
+  // Prover creates and sends:
+  const O = mod(secret_r + public_r * trustees_secret)
+
   return { LR, O, R }
 }
+
+/** Fiat-Shamir deterministic PRNG challenge integers */
+const prngR = (cipher_lock: RP, g_to_trustees_keyshare: RP, R: RP, LR: RP) =>
+  bigint_from_seed(['partial_decryption_proof', cipher_lock, g_to_trustees_keyshare, R, LR, G].join(','))
 
 /** Verifies a non-interactive Zero Knowledge proof of a valid partial decryption
  *  by checking these two logs are equivalent:
@@ -182,7 +186,7 @@ export async function verify_partial_decryption_proof(
   { LR, O, R }: AsyncReturnType<typeof generate_partial_decryption_proof>,
 ): Promise<boolean> {
   // Recalculate deterministic verifier nonce
-  const public_r = await bigint_from_seed(`${cipher_lock} ${g_to_trustees_keyshare}`)
+  const public_r = await prngR(cipher_lock, g_to_trustees_keyshare, R, LR)
 
   // Verifier checks:
   // g ^ O

--- a/src/crypto/threshold-keygen.ts
+++ b/src/crypto/threshold-keygen.ts
@@ -85,7 +85,7 @@ export const compute_pub_key = sum_points
 /** Each party Pⱼ of Q broadcast
     dⱼ = c[1]^(sⱼ)
 similar to DKG scheme */
-export const partial_decrypt = (unlock: RP, private_key_share: bigint) => unlock.multiply(private_key_share)
+export const partial_decrypt = (lock: RP, private_key_share: bigint) => lock.multiply(private_key_share)
 
 /** then compute:
     d = d[1]^λ[1] ... d[t]^λ[t]


### PR DESCRIPTION
Copied in relevant previously-written `crypto/` unit tests, cleaned them up a bit, updated them for recent code changes, and added a few more where helpful.

They can all be run with `bun test:crypto`. They're also included in `npm run unit` (which also includes IRV tallying unit tests).

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/293a257c-66d3-4826-86a4-c5fd24360aac" />

Also bumped underlying version to `v1.1`, since Fiat-Shamir PRNG have been upgraded. Confirmed there are no open elections affected.