### PR TITLE
Fixed console errors in SIV

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/react-dom": "18.2.0"
   },
   "dependencies": {
-    "@ant-design/icons": "~4.7",
+    "@ant-design/icons": "^5.0.0",
     "@codemirror/lang-json": "^6.0.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,20 +1,27 @@
 {
-  "name": "Elections",
-  "short_name": "Elections",
+  "name": "SIV",
+  "short_name": "Secure Internet Voting",
+  "description": "Fast, private, and verifiable online voting platform with cryptographic security",
+  "start_url": "/admin",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "scope": "/",
+  "lang": "en",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "categories": ["productivity", "utilities"],
   "icons": [
     {
       "src": "/android-chrome-192x192.png?v=2",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/android-chrome-512x512.png?v=2",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "start_url": "https://siv.org/admin",
-  "display": "standalone"
+  ]
 }


### PR DESCRIPTION
Hi @dsernst,

This is just a very light PR fixing a couple of errors I noticed in the Dev Tools console.

  ## Issues Fixed
  - React DOM property warning: `fill-rule` vs `fillRule` from @ant-design/icons v4.7
  - Web manifest warning: `start_url` origin mismatch using absolute URL

  ## Changes
  - **@ant-design/icons**: Upgraded from v4.7 to v5.0.0 to resolve DOM property warnings
  - **site.webmanifest**:
    - Changed `start_url` from absolute URL to relative path `/admin`
    - Enhanced with better metadata (description, orientation, scope, language)
    - Added icon purposes for improved PWA support
