### PR TITLE
Upgrade to nextjs@13

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,28 +1,26 @@
 // @ts-check
 const withMDX = require('@next/mdx')()
-const withTM = require('next-transpile-modules')(['lodash-es'])
 
 /**
  * @type {import('next').NextConfig}
  **/
-const nextConfig = withMDX(
-  withTM({
-    async redirects() {
-      return [
-        {
-          destination: 'https://docs.siv.org/research-in-progress/ukraine',
-          permanent: true,
-          source: '/ukraine',
-        },
-      ]
-    },
-    typescript: {
-      // !! WARN !!
-      // Dangerously allow production builds to successfully complete even if
-      // your project has type errors.
-      // ignoreBuildErrors: true,
-    },
-  }),
-)
+const nextConfig = withMDX({
+  async redirects() {
+    return [
+      {
+        destination: 'https://docs.siv.org/research-in-progress/ukraine',
+        permanent: true,
+        source: '/ukraine',
+      },
+    ]
+  },
+  typescript: {
+    // !! WARN !!
+    // Dangerously allow production builds to successfully complete even if
+    // your project has type errors.
+    // ignoreBuildErrors: true,
+  },
+  transpilePackages: ['lodash-es'],
+})
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "mailgun-js": "^0.22.0",
     "moment": "^2.29.1",
     "next": "^13.5.11",
-    "next-transpile-modules": "8",
     "patch-package": "^6.4.7",
     "pdf-lib": "^1.16.0",
     "postinstall-postinstall": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash-es": "^4.17.15",
     "mailgun-js": "^0.22.0",
     "moment": "^2.29.1",
-    "next": "12",
+    "next": "^13.5.11",
     "next-transpile-modules": "8",
     "patch-package": "^6.4.7",
     "pdf-lib": "^1.16.0",

--- a/src/_shared/Button.tsx
+++ b/src/_shared/Button.tsx
@@ -19,7 +19,7 @@ export const Button = ({
 }: ButtonProps & {
   href: string
 }): JSX.Element => (
-  <Link href={href}>
+  <Link href={href} legacyBehavior>
     <a style={style}>
       {children}
       <style jsx>{`

--- a/src/about/AcademicResearchPapers.tsx
+++ b/src/about/AcademicResearchPapers.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import React, { Fragment } from 'react'
 import { darkBlue } from 'src/homepage/colors'
 

--- a/src/about/Team.tsx
+++ b/src/about/Team.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 
 import ariana from './team/ariana.png'
 import david from './team/david.png'

--- a/src/admin/AllYourElections.tsx
+++ b/src/admin/AllYourElections.tsx
@@ -32,9 +32,7 @@ export const AllYourElections = () => {
           {data?.elections?.map(({ created_at, election_title, id }: Election) => (
             <li key={id}>
               <Link href={`/admin/${id}/voters`}>
-                <a>
-                  <TimeAgo datetime={new Date(created_at._seconds * 1000)} />: {election_title}
-                </a>
+                <TimeAgo datetime={new Date(created_at._seconds * 1000)} />: {election_title}
               </Link>
             </li>
           ))}

--- a/src/admin/BallotDesign/Wizard.tsx
+++ b/src/admin/BallotDesign/Wizard.tsx
@@ -46,13 +46,13 @@ export const Wizard = ({ design, setDesign }: { design: string; setDesign: (s: s
                   </span>
                 }
               >
-                <span className="relative top-0 text-sm text-indigo-500 left-1">
+                <span className="relative top-0 left-1 text-sm text-indigo-500">
                   <QuestionCircleOutlined />
                 </span>
               </Tooltip>
             </label>
             {/* Question ID Input */}
-            <div className="flex items-center justify-between">
+            <div className="flex justify-between items-center">
               <input
                 className="p-1 text-sm"
                 onChange={({ target }) => {
@@ -84,7 +84,7 @@ export const Wizard = ({ design, setDesign }: { design: string; setDesign: (s: s
 
               {/* Type dropdown */}
               <div className="relative">
-                <span className="absolute z-20 scale-75 right-3 top-2 opacity-60">▼</span>
+                <span className="absolute top-2 right-3 z-20 opacity-60 scale-75">▼</span>
                 <select
                   className="appearance-none border border-solid border-gray-200 text-[13px] rounded focus:ring-blue-500 focus:border-blue-500 w-full p-2.5 shadow-sm relative"
                   onChange={({ target }) => {
@@ -157,7 +157,7 @@ export const Wizard = ({ design, setDesign }: { design: string; setDesign: (s: s
               <div className="mt-1">
                 <label className="text-[10px] italic">Min score?</label>
                 <input
-                  className="p-1 m-1 text-sm w-14"
+                  className="p-1 m-1 w-14 text-sm"
                   onChange={({ target }) => {
                     const update = +target.value
                     const new_json = [...json]
@@ -170,7 +170,7 @@ export const Wizard = ({ design, setDesign }: { design: string; setDesign: (s: s
 
                 <label className="ml-5 text-[10px] italic">Max score?</label>
                 <input
-                  className="p-1 ml-1 text-sm w-14"
+                  className="p-1 ml-1 w-14 text-sm"
                   onChange={({ target }) => {
                     const update = +target.value
                     const new_json = [...json]
@@ -186,10 +186,10 @@ export const Wizard = ({ design, setDesign }: { design: string; setDesign: (s: s
             {json[questionIndex].type == 'budget' && (
               <div className="mt-1">
                 <label className="text-[10px] italic">Total available?</label>
-                <div className="relative inline">
+                <div className="inline relative">
                   <div className="absolute text-lg opacity-50 -top-[3px] left-3">$</div>
                   <input
-                    className="w-24 p-1 m-1 text-sm text-right"
+                    className="p-1 m-1 w-24 text-sm text-right"
                     onChange={({ target }) => {
                       const update = +target.value
                       const new_json = [...json]

--- a/src/admin/Conventions/AllYourConventions.tsx
+++ b/src/admin/Conventions/AllYourConventions.tsx
@@ -29,9 +29,7 @@ export const AllYourConventions = () => {
           {data?.conventions?.map(({ convention_title, created_at, id }: Convention) => (
             <li key={id}>
               <Link href={`/admin/conventions/${id}`}>
-                <a>
-                  <TimeAgo datetime={new Date(created_at._seconds * 1000)} />: {convention_title}
-                </a>
+                <TimeAgo datetime={new Date(created_at._seconds * 1000)} />: {convention_title}
               </Link>
             </li>
           ))}

--- a/src/admin/Conventions/ListOfQRSets.tsx
+++ b/src/admin/Conventions/ListOfQRSets.tsx
@@ -14,7 +14,7 @@ export const ListOfQRSets = () => {
           <span className="inline-block w-20">Set of {number} </span>
 
           {/* Download */}
-          <Link href={`/admin/conventions/download?c=${id}&set=${i}`} target="_blank" className="pl-1">
+          <Link className="pl-1" href={`/admin/conventions/download?c=${id}&set=${i}`} target="_blank">
             Download
           </Link>
 

--- a/src/admin/Conventions/ListOfQRSets.tsx
+++ b/src/admin/Conventions/ListOfQRSets.tsx
@@ -14,10 +14,8 @@ export const ListOfQRSets = () => {
           <span className="inline-block w-20">Set of {number} </span>
 
           {/* Download */}
-          <Link href={`/admin/conventions/download?c=${id}&set=${i}`} target="_blank">
-            <a className="pl-1" target="_blank">
-              Download
-            </a>
+          <Link href={`/admin/conventions/download?c=${id}&set=${i}`} target="_blank" className="pl-1">
+            Download
           </Link>
 
           {/* Time */}

--- a/src/admin/Conventions/ManageConventionPage.tsx
+++ b/src/admin/Conventions/ManageConventionPage.tsx
@@ -27,7 +27,7 @@ export const ManageConventionPage = () => {
       <HeaderBar />
       <main className="p-4 overflow-clip sm:px-8">
         {/* Back link */}
-        <Link href="/admin/conventions" className="block mt-2 opacity-60 transition hover:opacity-100">
+        <Link className="block mt-2 opacity-60 transition hover:opacity-100" href="/admin/conventions">
           ← Back to all Conventions
         </Link>
 

--- a/src/admin/Conventions/ManageConventionPage.tsx
+++ b/src/admin/Conventions/ManageConventionPage.tsx
@@ -25,10 +25,10 @@ export const ManageConventionPage = () => {
       <Head title={`Manage${convention_title ? `: ${convention_title}` : '  Convention'}`} />
 
       <HeaderBar />
-      <main className="p-4 sm:px-8 overflow-clip">
+      <main className="p-4 overflow-clip sm:px-8">
         {/* Back link */}
-        <Link href="/admin/conventions">
-          <a className="block mt-2 transition opacity-60 hover:opacity-100">← Back to all Conventions</a>
+        <Link href="/admin/conventions" className="block mt-2 opacity-60 transition hover:opacity-100">
+          ← Back to all Conventions
         </Link>
 
         {/* Title */}

--- a/src/admin/Conventions/SetRedirection.tsx
+++ b/src/admin/Conventions/SetRedirection.tsx
@@ -157,7 +157,7 @@ export const SetRedirection = () => {
                   {is_active_redirect ? (
                     'Active'
                   ) : (
-                    <span className="px-3 bg-white border border-solid rounded-lg border-black/50">Set</span>
+                    <span className="px-3 bg-white rounded-lg border border-solid border-black/50">Set</span>
                   )}
                 </td>
               </tr>

--- a/src/admin/Conventions/YourConventionsLink.tsx
+++ b/src/admin/Conventions/YourConventionsLink.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export const YourConventionsLink = () => {
   return (
-    <Link href="/admin/conventions">
+    <Link href="/admin/conventions" legacyBehavior>
       <div className="pb-2 pl-2 pr-4 -ml-2 transition border-2 border-transparent border-solid rounded-lg cursor-pointer sm:pl-4 sm:-ml-4 hover:border-[#002868] mt-14">
         <h2>
           Your Conventions <BetaBadge />

--- a/src/admin/HeaderBar.tsx
+++ b/src/admin/HeaderBar.tsx
@@ -22,8 +22,8 @@ export const HeaderBar = (): JSX.Element => {
       {/* Logo */}
       <section className="min-w-[80px] py-4 sm:min-w-[281px]">
         <Link
-          href={'/admin'}
           className="relative flex items-center p-1.5 ml-3 top-px active:opacity-60 hover:opacity-80"
+          href={'/admin'}
           onClick={() => {
             const el = document.getElementById('main-content')
             if (el) el.scrollTop = 0

--- a/src/admin/HeaderBar.tsx
+++ b/src/admin/HeaderBar.tsx
@@ -21,22 +21,21 @@ export const HeaderBar = (): JSX.Element => {
     <div className="bg-gradient-to-r from-[#010b26] to-[#072054] text-white flex w-full justify-between" id={headerId}>
       {/* Logo */}
       <section className="min-w-[80px] py-4 sm:min-w-[281px]">
-        <Link href={'/admin'}>
-          <a
-            className="relative flex items-center p-1.5 ml-3 top-px active:opacity-60 hover:opacity-80"
-            onClick={() => {
-              const el = document.getElementById('main-content')
-              if (el) el.scrollTop = 0
-            }}
-          >
-            <Image
-              alt="SIV"
-              className="opacity-90 brightness-0 invert"
-              height={(logoWidth * 219) / 482}
-              src={logo}
-              width={logoWidth}
-            />
-          </a>
+        <Link
+          href={'/admin'}
+          className="relative flex items-center p-1.5 ml-3 top-px active:opacity-60 hover:opacity-80"
+          onClick={() => {
+            const el = document.getElementById('main-content')
+            if (el) el.scrollTop = 0
+          }}
+        >
+          <Image
+            alt="SIV"
+            className="opacity-90 brightness-0 invert"
+            height={(logoWidth * 219) / 482}
+            src={logo}
+            width={logoWidth}
+          />
         </Link>
       </section>
 

--- a/src/admin/LoginPage/AboutSection.tsx
+++ b/src/admin/LoginPage/AboutSection.tsx
@@ -6,7 +6,7 @@ import { breakpoint } from './LoginPage'
 export const AboutSection = () => {
   return (
     <aside>
-      <Link href="/">
+      <Link href="/" legacyBehavior>
         <a>
           <img className="logo" src="/login/circle-logo.png" />
         </a>

--- a/src/admin/LoginPage/Headerbar.tsx
+++ b/src/admin/LoginPage/Headerbar.tsx
@@ -8,7 +8,7 @@ export const Headerbar = ({ hideLogin }: { hideLogin?: boolean }) => {
     <header>
       <div>
         <h2>
-          <Link href="/">
+          <Link href="/" legacyBehavior>
             <a>Secure Internet Voting</a>
           </Link>
         </h2>

--- a/src/admin/Sidebar.tsx
+++ b/src/admin/Sidebar.tsx
@@ -27,8 +27,8 @@ export const SidebarContent = ({ closeMenu = () => {} }: { closeMenu?: () => voi
     <div className="sidebar">
       <main>
         <Link
-          href="/admin"
           className="hover:!bg-white/0 !p-0"
+          href="/admin"
           onClick={() => {
             closeMenu()
             const el = document.getElementById('main-content')

--- a/src/admin/Sidebar.tsx
+++ b/src/admin/Sidebar.tsx
@@ -26,17 +26,16 @@ export const SidebarContent = ({ closeMenu = () => {} }: { closeMenu?: () => voi
   return (
     <div className="sidebar">
       <main>
-        <Link href="/admin">
-          <a
-            className="hover:!bg-white/0 !p-0"
-            onClick={() => {
-              closeMenu()
-              const el = document.getElementById('main-content')
-              if (el) el.scrollTop = 0
-            }}
-          >
-            <h2 className="logo sm:hidden">SIV</h2>
-          </a>
+        <Link
+          href="/admin"
+          className="hover:!bg-white/0 !p-0"
+          onClick={() => {
+            closeMenu()
+            const el = document.getElementById('main-content')
+            if (el) el.scrollTop = 0
+          }}
+        >
+          <h2 className="logo sm:hidden">SIV</h2>
         </Link>
 
         {election_id && (
@@ -47,7 +46,7 @@ export const SidebarContent = ({ closeMenu = () => {} }: { closeMenu?: () => voi
                 <ApartmentOutlined style={{ marginRight: 5 }} /> Election Management
               </label>
               {steps.map((name) => (
-                <Link href={`/admin/${election_id}/${urled(name)}`} key={name}>
+                <Link href={`/admin/${election_id}/${urled(name)}`} key={name} legacyBehavior>
                   <a className={urled(name) === section ? 'current' : ''} onClick={closeMenu}>
                     {name !== 'Voters' && <input checked={completed[name]} readOnly type="checkbox" />}
                     {name}
@@ -62,7 +61,7 @@ export const SidebarContent = ({ closeMenu = () => {} }: { closeMenu?: () => voi
                 <SnippetsOutlined style={{ marginRight: 5 }} />
                 Post Election
               </label>
-              <Link href={`/admin/${election_id}/marked-ballots`}>
+              <Link href={`/admin/${election_id}/marked-ballots`} legacyBehavior>
                 <a className={'marked-ballots' === section ? 'current' : ''} onClick={closeMenu}>
                   Marked Ballots
                 </a>
@@ -75,10 +74,10 @@ export const SidebarContent = ({ closeMenu = () => {} }: { closeMenu?: () => voi
                 <LinkOutlined style={{ marginRight: 5 }} />
                 Public Pages
               </label>
-              <Link href={`/election/${election_id}/vote`}>
+              <Link href={`/election/${election_id}/vote`} legacyBehavior>
                 <a target="_blank">Cast Vote</a>
               </Link>
-              <Link href={`/election/${election_id}`}>
+              <Link href={`/election/${election_id}`} legacyBehavior>
                 <a target="_blank">Election Status</a>
               </Link>
             </>
@@ -91,10 +90,10 @@ export const SidebarContent = ({ closeMenu = () => {} }: { closeMenu?: () => voi
           <QuestionCircleOutlined style={{ marginRight: 5 }} />
           Support
         </label>
-        <Link href="/protocol">
+        <Link href="/protocol" legacyBehavior>
           <a target="_blank">Protocol Overview</a>
         </Link>
-        <Link href="mailto:help@siv.org">
+        <Link href="mailto:help@siv.org" legacyBehavior>
           <a>Get Help</a>
         </Link>
       </div>

--- a/src/admin/Voters/InvalidVotersTable.tsx
+++ b/src/admin/Voters/InvalidVotersTable.tsx
@@ -42,13 +42,19 @@ export const InvalidVotersTable = ({ hide_approved, hide_voted }: { hide_approve
             <tr key={email}>
               <td className={struckthrough}>{index + 1}</td>
               <td className={struckthrough}>{email}</td>
-              <td className={`${struckthrough} font-mono text-[12px]`}>
+              <td className={`font-mono ${struckthrough} text-[12px]`}>
                 {mask_tokens ? mask(auth_token) : auth_token}
               </td>
 
               <td className="p-0 text-center">
                 {has_voted ? (
-                  <Image className="object-contain scale-25" height={23} src={InvalidatedVoteIcon} width={23} />
+                  <Image
+                    alt="Invalidated Vote"
+                    className="object-contain scale-25"
+                    height={23}
+                    src={InvalidatedVoteIcon}
+                    width={23}
+                  />
                 ) : null}
               </td>
 

--- a/src/admin/Voters/PrivacyProtectorsWarning.tsx
+++ b/src/admin/Voters/PrivacyProtectorsWarning.tsx
@@ -8,7 +8,7 @@ export const PrivacyProtectorsWarning = () => {
 
   return (
     <div>
-      <details className="px-4 py-2 border-2 border-orange-200 border-solid rounded-lg group">
+      <details className="px-4 py-2 rounded-lg border-2 border-orange-200 border-solid group">
         <summary className="py-2 cursor-pointer">
           <span className="opacity-50">Reminder:</span> Unlocking will need each Privacy Protector&apos;s device.
           <span className="ml-2 text-xs opacity-50">
@@ -24,9 +24,7 @@ export const PrivacyProtectorsWarning = () => {
           <div>✅ Make sure they still have access.</div>
           <div>🚫 If not, you can create a new election.</div>
           <div>
-            <Link href={`/admin/${election_id}/privacy`}>
-              <a>Review Privacy Protectors: {trustees.length - 1}</a>
-            </Link>
+            <Link href={`/admin/${election_id}/privacy`}>Review Privacy Protectors: {trustees.length - 1}</Link>
           </div>
         </div>
       </details>

--- a/src/admin/Voters/RequestEsignatures.tsx
+++ b/src/admin/Voters/RequestEsignatures.tsx
@@ -29,7 +29,7 @@ export const RequestEsignatures = () => {
     <div>
       <label className="cursor-pointer" onClick={toggleESignature}>
         <span className="mr-1.5 relative top-0.5">
-          <Image height={(218 / 700) * 70} layout="fixed" src={esignatureIcon} width={70} />
+          <Image alt="esignature" height={(218 / 700) * 70} layout="fixed" src={esignatureIcon} width={70} />
         </span>
         Request Drawn Signatures?
       </label>

--- a/src/admin/Voters/UnlockedStatus.tsx
+++ b/src/admin/Voters/UnlockedStatus.tsx
@@ -30,7 +30,7 @@ export const UnlockedStatus = () => {
       ) : !more_to_unlock ? (
         <p>
           ✅ Successfully{' '}
-          <Link href={`/election/${election_id}`}>
+          <Link href={`/election/${election_id}`} legacyBehavior>
             <a className="font-medium text-black cursor-pointer" target="_blank">
               unlocked {unlocked_votes.length}
             </a>

--- a/src/convention/ConventionQRPage.tsx
+++ b/src/convention/ConventionQRPage.tsx
@@ -9,7 +9,7 @@ export const ConventionQRPage = () => {
   if (!convention_id) return null
 
   return (
-    <div className="flex flex-col justify-between max-w-lg min-h-screen p-4 pt-6 mx-auto font-sans">
+    <div className="flex flex-col justify-between p-4 pt-6 mx-auto max-w-lg min-h-screen font-sans">
       {/* Headerbar */}
       <header className="font-semibold text-center">Secure Internet Voting</header>
 
@@ -25,17 +25,16 @@ export const ConventionQRPage = () => {
                   No active election yet.
                 </>
               ) : (
-                <div className="-ml-10 ">
+                <div className="-ml-10">
                   <Spinner />
-                  <span className="ml-2 ">Loading your ballot...</span>
+                  <span className="ml-2">Loading your ballot...</span>
                 </div>
               )}
             </div>
           ) : (
             // Error
             <>
-              <div className="text-2xl -mt-28 opacity-90">Error: {errorMessage}</div>
-
+              <div className="-mt-28 text-2xl opacity-90">Error: {errorMessage}</div>
               {/* Debug info */}
               <div className="mt-10 opacity-70">
                 <div className="text-sm opacity-70">Debug Info</div>

--- a/src/docs/DocsIndexPage.tsx
+++ b/src/docs/DocsIndexPage.tsx
@@ -11,7 +11,7 @@ export const DocsIndexPage = ({ files }: DocsIndexPageProps) => {
       <ul>
         {files.map((file) => (
           <li key={file}>
-            <Link href={`docs/${file}`}>
+            <Link href={`docs/${file}`} legacyBehavior>
               <a>{startCase(file)}</a>
             </Link>
           </li>

--- a/src/faq/HeaderBar.tsx
+++ b/src/faq/HeaderBar.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 export const HeaderBar = (): JSX.Element => (
   <div className="p-4 bg-gradient-to-r from-[#010b26] to-[#072054]">
     <div className="max-w-[750px] mx-auto">
-      <Link href="/" className="text-[24px] font-bold hover:no-underline text-white">
+      <Link className="text-[24px] font-bold hover:no-underline text-white" href="/">
         Secure Internet Voting
       </Link>
     </div>

--- a/src/faq/HeaderBar.tsx
+++ b/src/faq/HeaderBar.tsx
@@ -3,8 +3,8 @@ import Link from 'next/link'
 export const HeaderBar = (): JSX.Element => (
   <div className="p-4 bg-gradient-to-r from-[#010b26] to-[#072054]">
     <div className="max-w-[750px] mx-auto">
-      <Link href="/">
-        <a className="text-[24px] font-bold hover:no-underline text-white">Secure Internet Voting</a>
+      <Link href="/" className="text-[24px] font-bold hover:no-underline text-white">
+        Secure Internet Voting
       </Link>
     </div>
   </div>

--- a/src/homepage/AboveFold.tsx
+++ b/src/homepage/AboveFold.tsx
@@ -12,12 +12,12 @@ export const AboveFold = () => (
     <h1>
       Secure Internet Voting
       <div className="underline-container">
-        <Image height={810} layout="responsive" src="/home3/yellow-underline.gif" width={1440} />
+        <Image alt="yellow underline" height={810} layout="responsive" src="/home3/yellow-underline.gif" width={1440} />
       </div>
     </h1>
     <h2>Fast. Private. Verifiable.</h2>
     <div className="phone-container">
-      <Image height={912} layout="responsive" src="/home3/above-interface.gif" width={464} />
+      <Image alt="above interface" height={912} layout="responsive" src="/home3/above-interface.gif" width={464} />
     </div>
     <p>Millions of people want to be able to vote from their phones.</p>
     <div>

--- a/src/homepage/AboveFold.tsx
+++ b/src/homepage/AboveFold.tsx
@@ -16,8 +16,8 @@ export const AboveFold = () => (
           alt="yellow underline"
           height={810}
           src="/home3/yellow-underline.gif"
+          style={{ height: 'auto', width: '100%' }}
           width={1440}
-          style={{ width: '100%', height: 'auto' }}
         />
       </div>
     </h1>
@@ -27,8 +27,8 @@ export const AboveFold = () => (
         alt="above interface"
         height={912}
         src="/home3/above-interface.gif"
+        style={{ height: 'auto', width: '100%' }}
         width={464}
-        style={{ width: '100%', height: 'auto' }}
       />
     </div>
     <p>Millions of people want to be able to vote from their phones.</p>

--- a/src/homepage/AboveFold.tsx
+++ b/src/homepage/AboveFold.tsx
@@ -12,12 +12,24 @@ export const AboveFold = () => (
     <h1>
       Secure Internet Voting
       <div className="underline-container">
-        <Image alt="yellow underline" height={810} layout="responsive" src="/home3/yellow-underline.gif" width={1440} />
+        <Image
+          alt="yellow underline"
+          height={810}
+          src="/home3/yellow-underline.gif"
+          width={1440}
+          style={{ width: '100%', height: 'auto' }}
+        />
       </div>
     </h1>
     <h2>Fast. Private. Verifiable.</h2>
     <div className="phone-container">
-      <Image alt="above interface" height={912} layout="responsive" src="/home3/above-interface.gif" width={464} />
+      <Image
+        alt="above interface"
+        height={912}
+        src="/home3/above-interface.gif"
+        width={464}
+        style={{ width: '100%', height: 'auto' }}
+      />
     </div>
     <p>Millions of people want to be able to vote from their phones.</p>
     <div>

--- a/src/homepage/AnAdditionalOption.tsx
+++ b/src/homepage/AnAdditionalOption.tsx
@@ -10,19 +10,19 @@ export const AnAdditionalOption = () => (
     <ul>
       <li>
         <div>
-          <Image height={1080} layout="responsive" priority src="/home3/methods-1.png" width={1920} />
+          <Image alt="in person" height={1080} layout="responsive" priority src="/home3/methods-1.png" width={1920} />
         </div>
         In Person
       </li>
       <li>
         <div>
-          <Image height={1080} layout="responsive" priority src="/home3/methods-2.png" width={1920} />
+          <Image alt="by mail" height={1080} layout="responsive" priority src="/home3/methods-2.png" width={1920} />
         </div>
         By Mail
       </li>
       <li>
         <div>
-          <Image height={223} layout="responsive" priority src="/home3/methods-3.png" width={256} />
+          <Image alt="online" height={223} layout="responsive" priority src="/home3/methods-3.png" width={256} />
         </div>
         Online
       </li>

--- a/src/homepage/AnAdditionalOption.tsx
+++ b/src/homepage/AnAdditionalOption.tsx
@@ -10,19 +10,40 @@ export const AnAdditionalOption = () => (
     <ul>
       <li>
         <div>
-          <Image alt="in person" height={1080} layout="responsive" priority src="/home3/methods-1.png" width={1920} />
+          <Image
+            alt="in person"
+            height={1080}
+            priority
+            src="/home3/methods-1.png"
+            width={1920}
+            style={{ width: '100%', height: 'auto' }}
+          />
         </div>
         In Person
       </li>
       <li>
         <div>
-          <Image alt="by mail" height={1080} layout="responsive" priority src="/home3/methods-2.png" width={1920} />
+          <Image
+            alt="by mail"
+            height={1080}
+            priority
+            src="/home3/methods-2.png"
+            width={1920}
+            style={{ width: '100%', height: 'auto' }}
+          />
         </div>
         By Mail
       </li>
       <li>
         <div>
-          <Image alt="online" height={223} layout="responsive" priority src="/home3/methods-3.png" width={256} />
+          <Image
+            alt="online"
+            height={223}
+            priority
+            src="/home3/methods-3.png"
+            width={256}
+            style={{ width: '100%', height: 'auto' }}
+          />
         </div>
         Online
       </li>

--- a/src/homepage/AnAdditionalOption.tsx
+++ b/src/homepage/AnAdditionalOption.tsx
@@ -15,8 +15,8 @@ export const AnAdditionalOption = () => (
             height={1080}
             priority
             src="/home3/methods-1.png"
+            style={{ height: 'auto', width: '100%' }}
             width={1920}
-            style={{ width: '100%', height: 'auto' }}
           />
         </div>
         In Person
@@ -28,8 +28,8 @@ export const AnAdditionalOption = () => (
             height={1080}
             priority
             src="/home3/methods-2.png"
+            style={{ height: 'auto', width: '100%' }}
             width={1920}
-            style={{ width: '100%', height: 'auto' }}
           />
         </div>
         By Mail
@@ -41,8 +41,8 @@ export const AnAdditionalOption = () => (
             height={223}
             priority
             src="/home3/methods-3.png"
+            style={{ height: 'auto', width: '100%' }}
             width={256}
-            style={{ width: '100%', height: 'auto' }}
           />
         </div>
         Online

--- a/src/homepage/Features.tsx
+++ b/src/homepage/Features.tsx
@@ -7,21 +7,42 @@ export const Features = () => (
     <div className="row">
       <div>
         <span className="easy">
-          <Image alt="easy" height={160} layout="responsive" priority src="/home3/features-1.gif" width={160} />
+          <Image
+            alt="easy"
+            height={160}
+            priority
+            src="/home3/features-1.gif"
+            width={160}
+            style={{ width: '100%', height: 'auto' }}
+          />
         </span>
         <h2>Easy To Use</h2>
         <p>Voters can vote from their preferred device in seconds, without needing to install anything.</p>
       </div>
       <div>
         <span className="quick">
-          <Image alt="quick" height={110} layout="responsive" priority src="/home3/features-2.gif" width={110} />
+          <Image
+            alt="quick"
+            height={110}
+            priority
+            src="/home3/features-2.gif"
+            width={110}
+            style={{ width: '100%', height: 'auto' }}
+          />
         </span>
         <h2>Quick Results</h2>
         <p>Ballots can be submitted, confirmed, and tallied instantly.</p>
       </div>
       <div>
         <span className="verifiable">
-          <Image alt="verifiable" height={170} layout="responsive" priority src="/home3/features-3.gif" width={170} />
+          <Image
+            alt="verifiable"
+            height={170}
+            priority
+            src="/home3/features-3.gif"
+            width={170}
+            style={{ width: '100%', height: 'auto' }}
+          />
         </span>
         <h2>Verifiable</h2>
         <p>Voters can personally verify that their vote was counted correctly & recount all votes themselves.</p>

--- a/src/homepage/Features.tsx
+++ b/src/homepage/Features.tsx
@@ -7,21 +7,21 @@ export const Features = () => (
     <div className="row">
       <div>
         <span className="easy">
-          <Image height={160} layout="responsive" priority src="/home3/features-1.gif" width={160} />
+          <Image alt="easy" height={160} layout="responsive" priority src="/home3/features-1.gif" width={160} />
         </span>
         <h2>Easy To Use</h2>
         <p>Voters can vote from their preferred device in seconds, without needing to install anything.</p>
       </div>
       <div>
         <span className="quick">
-          <Image height={110} layout="responsive" priority src="/home3/features-2.gif" width={110} />
+          <Image alt="quick" height={110} layout="responsive" priority src="/home3/features-2.gif" width={110} />
         </span>
         <h2>Quick Results</h2>
         <p>Ballots can be submitted, confirmed, and tallied instantly.</p>
       </div>
       <div>
         <span className="verifiable">
-          <Image height={170} layout="responsive" priority src="/home3/features-3.gif" width={170} />
+          <Image alt="verifiable" height={170} layout="responsive" priority src="/home3/features-3.gif" width={170} />
         </span>
         <h2>Verifiable</h2>
         <p>Voters can personally verify that their vote was counted correctly & recount all votes themselves.</p>

--- a/src/homepage/Features.tsx
+++ b/src/homepage/Features.tsx
@@ -12,8 +12,8 @@ export const Features = () => (
             height={160}
             priority
             src="/home3/features-1.gif"
+            style={{ height: 'auto', width: '100%' }}
             width={160}
-            style={{ width: '100%', height: 'auto' }}
           />
         </span>
         <h2>Easy To Use</h2>
@@ -26,8 +26,8 @@ export const Features = () => (
             height={110}
             priority
             src="/home3/features-2.gif"
+            style={{ height: 'auto', width: '100%' }}
             width={110}
-            style={{ width: '100%', height: 'auto' }}
           />
         </span>
         <h2>Quick Results</h2>
@@ -40,8 +40,8 @@ export const Features = () => (
             height={170}
             priority
             src="/home3/features-3.gif"
+            style={{ height: 'auto', width: '100%' }}
             width={170}
-            style={{ width: '100%', height: 'auto' }}
           />
         </span>
         <h2>Verifiable</h2>

--- a/src/homepage/Footer.tsx
+++ b/src/homepage/Footer.tsx
@@ -19,7 +19,7 @@ export const Footer = (): JSX.Element => (
         <EmailSignup />
 
         {/* Right: Brand Info */}
-        <div className="flex flex-col items-center text-sm md:items-end md:mt-9 mt-14">
+        <div className="flex flex-col items-center mt-14 text-sm md:items-end md:mt-9">
           {/* Logo */}
           <Image alt="SIV" height={(logoWidth * 219) / 482} src={logo} width={logoWidth} />
 

--- a/src/homepage/HeaderBar.tsx
+++ b/src/homepage/HeaderBar.tsx
@@ -11,32 +11,32 @@ export const HeaderBar = () => {
   return (
     <header className="w-full px-6 py-6 mx-auto border-b border-gray-200 max-w-[1440px] sm:px-0.5 bg-gradient-to-r from-white via-gray-100 to-white flex flex-col items-center justify-between gap-4 sm:flex-row">
       {/* Logo */}
-      <Link href="/">
-        <a className="relative p-1.5 pt-2 pr-[5px] rounded-lg leading-none hover:bg-white hover:shadow top-px active:opacity-60 hover:border-gray-200 border border-solid border-transparent">
-          <Image alt="SIV" height={(logoWidth * 219) / 482} src={logo} width={logoWidth} />
-        </a>
+      <Link
+        href="/"
+        className="relative p-1.5 pt-2 pr-[5px] rounded-lg leading-none hover:bg-white hover:shadow top-px active:opacity-60 hover:border-gray-200 border border-solid border-transparent"
+      >
+        <Image alt="SIV" height={(logoWidth * 219) / 482} src={logo} width={logoWidth} />
       </Link>
 
       {/* Nav Links */}
-      <nav className="flex flex-wrap justify-center gap-2 sm:gap-4">
+      <nav className="flex flex-wrap gap-2 justify-center sm:gap-4">
         {[
           ['Docs', 'https://docs.siv.org'],
           ['Blog', 'https://blog.siv.org'],
           ['FAQ', '/faq'],
           ['Contributors', '/about'],
         ].map(([label, href]) => (
-          <Link href={href} key={label}>
-            <a className={`${sharedStyles} hover:bg-gray-200 active:bg-gray-300`}>{label}</a>
+          <Link href={href} key={label} className={`${sharedStyles} hover:bg-gray-200 active:bg-gray-300`}>
+            {label}
           </Link>
         ))}
 
         {/* Sign In Button */}
-        <Link href="/admin">
-          <a
-            className={`${sharedStyles} shadow bg-gradient-to-b from-indigo-100/60 to-white/60 hover:from-indigo-200/80 hover:to-indigo-100/50 active:bg-indigo-200`}
-          >
-            Sign In
-          </a>
+        <Link
+          href="/admin"
+          className={`bg-gradient-to-b shadow ${sharedStyles} from-indigo-100/60 to-white/60 hover:from-indigo-200/80 hover:to-indigo-100/50 active:bg-indigo-200`}
+        >
+          Sign In
         </Link>
       </nav>
     </header>

--- a/src/homepage/HeaderBar.tsx
+++ b/src/homepage/HeaderBar.tsx
@@ -12,8 +12,8 @@ export const HeaderBar = () => {
     <header className="w-full px-6 py-6 mx-auto border-b border-gray-200 max-w-[1440px] sm:px-0.5 bg-gradient-to-r from-white via-gray-100 to-white flex flex-col items-center justify-between gap-4 sm:flex-row">
       {/* Logo */}
       <Link
-        href="/"
         className="relative p-1.5 pt-2 pr-[5px] rounded-lg leading-none hover:bg-white hover:shadow top-px active:opacity-60 hover:border-gray-200 border border-solid border-transparent"
+        href="/"
       >
         <Image alt="SIV" height={(logoWidth * 219) / 482} src={logo} width={logoWidth} />
       </Link>
@@ -26,15 +26,15 @@ export const HeaderBar = () => {
           ['FAQ', '/faq'],
           ['Contributors', '/about'],
         ].map(([label, href]) => (
-          <Link href={href} key={label} className={`${sharedStyles} hover:bg-gray-200 active:bg-gray-300`}>
+          <Link className={`${sharedStyles} hover:bg-gray-200 active:bg-gray-300`} href={href} key={label}>
             {label}
           </Link>
         ))}
 
         {/* Sign In Button */}
         <Link
-          href="/admin"
           className={`bg-gradient-to-b shadow ${sharedStyles} from-indigo-100/60 to-white/60 hover:from-indigo-200/80 hover:to-indigo-100/50 active:bg-indigo-200`}
+          href="/admin"
         >
           Sign In
         </Link>

--- a/src/homepage/NowPossible.tsx
+++ b/src/homepage/NowPossible.tsx
@@ -10,7 +10,7 @@ export const NowPossible = () => (
       <a href="/faq">Frequently Asked Questions</a>
     </p>
     <div>
-      <Image layout="fill" placeholder="blur" src={backgroundPurple} />
+      <Image alt="background purple" layout="fill" placeholder="blur" src={backgroundPurple} />
     </div>
     <style jsx>{`
       section {

--- a/src/homepage/NowPossible.tsx
+++ b/src/homepage/NowPossible.tsx
@@ -10,7 +10,7 @@ export const NowPossible = () => (
       <a href="/faq">Frequently Asked Questions</a>
     </p>
     <div>
-      <Image alt="background purple" placeholder="blur" src={backgroundPurple} fill style={{ objectFit: 'cover' }} />
+      <Image alt="background purple" fill placeholder="blur" src={backgroundPurple} style={{ objectFit: 'cover' }} />
     </div>
     <style jsx>{`
       section {

--- a/src/homepage/NowPossible.tsx
+++ b/src/homepage/NowPossible.tsx
@@ -10,7 +10,7 @@ export const NowPossible = () => (
       <a href="/faq">Frequently Asked Questions</a>
     </p>
     <div>
-      <Image alt="background purple" layout="fill" placeholder="blur" src={backgroundPurple} />
+      <Image alt="background purple" placeholder="blur" src={backgroundPurple} fill style={{ objectFit: 'cover' }} />
     </div>
     <style jsx>{`
       section {

--- a/src/homepage/OnePersonOneVote.tsx
+++ b/src/homepage/OnePersonOneVote.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 
 import { darkBlue } from './colors'
 

--- a/src/homepage/Verifiability.tsx
+++ b/src/homepage/Verifiability.tsx
@@ -70,7 +70,7 @@ export const Verifiability = () => (
 const Screenshot = ({ image, label }: { image: StaticImageData; label: string }) => (
   <div>
     <span className="px-2">{label}</span>
-    <Image height={516} placeholder="blur" src={image} width={992} style={{ width: '100%', height: 'auto' }} />
+    <Image height={516} placeholder="blur" src={image} width={992} />
     <style jsx>{`
       div {
         position: relative;

--- a/src/homepage/Verifiability.tsx
+++ b/src/homepage/Verifiability.tsx
@@ -70,7 +70,7 @@ export const Verifiability = () => (
 const Screenshot = ({ image, label }: { image: StaticImageData; label: string }) => (
   <div>
     <span className="px-2">{label}</span>
-    <Image height={516} layout="responsive" placeholder="blur" src={image} width={992} />
+    <Image height={516} placeholder="blur" src={image} width={992} style={{ width: '100%', height: 'auto' }} />
     <style jsx>{`
       div {
         position: relative;

--- a/src/homepage/Verifiability.tsx
+++ b/src/homepage/Verifiability.tsx
@@ -1,4 +1,4 @@
-import Image, { StaticImageData } from 'next/image'
+import Image, { StaticImageData } from 'next/legacy/image'
 import verifiability1 from 'public/home3/verifiability-1.png'
 import verifiability2 from 'public/home3/verifiability-2.png'
 

--- a/src/protocol/Introduction.tsx
+++ b/src/protocol/Introduction.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import Link from 'next/link'
 
 import logo from './siv-logo.png'
@@ -6,7 +6,7 @@ import logo from './siv-logo.png'
 export const Introduction = () => {
   return (
     <div style={{ padding: '10px 30px' }}>
-      <Link href="/">
+      <Link href="/" legacyBehavior>
         <a className="logo-container">
           <Image src={logo} />
         </a>

--- a/src/protocol/Invitation.tsx
+++ b/src/protocol/Invitation.tsx
@@ -79,8 +79,8 @@ export const InvitationExplanation = () => (
     <p>
       <em>
         See{' '}
-        <Link href="/faq#1p1v">
-          <a target="_blank">How does SIV ensure One Vote per Person?</a>
+        <Link href="/faq#1p1v" target="_blank">
+          How does SIV ensure One Vote per Person?
         </Link>{' '}
         for more.
       </em>

--- a/src/status/IRVTallies.tsx
+++ b/src/status/IRVTallies.tsx
@@ -28,7 +28,7 @@ export const IRVTallies = ({
       )}
 
       {/* Horizontal list of rounds */}
-      <div className="flex pb-3 -ml-5 overflow-x-scroll">
+      <div className="flex overflow-x-scroll pb-3 -ml-5">
         {results.rounds.map((round, index) => (
           // Vertical round results
           <div key={index}>
@@ -67,7 +67,7 @@ const CheckForTies = ({
 
   return (
     <div
-      className="px-1 ml-5 border border-yellow-400 border-solid rounded cursor-pointer text-black/70 hover:bg-yellow-50"
+      className="px-1 ml-5 rounded border border-yellow-400 border-solid cursor-pointer text-black/70 hover:bg-yellow-50"
       onClick={() =>
         alert(
           `Round ${

--- a/src/trustee/HeaderBar.tsx
+++ b/src/trustee/HeaderBar.tsx
@@ -3,10 +3,10 @@ import Link from 'next/link'
 export const HeaderBar = (): JSX.Element => (
   <div className="headerbar-container">
     <div>
-      <Link href="/">
+      <Link href="/" legacyBehavior>
         <a className="big">Secure Internet Voting</a>
       </Link>
-      <Link href="/protocol">
+      <Link href="/protocol" legacyBehavior>
         <a>Protocol</a>
       </Link>
     </div>

--- a/src/vote/submitted/SubmittedScreen.tsx
+++ b/src/vote/submitted/SubmittedScreen.tsx
@@ -33,7 +33,7 @@ export function SubmittedScreen({
     <NoSsr>
       <UnverifiedEmailModal />
       <InvalidatedVoteMessage />
-      <Link as={`/election/${election_id}`} href="/election/[election_id]">
+      <Link as={`/election/${election_id}`} href="/election/[election_id]" legacyBehavior>
         <a id="status-page" target="_blank">
           <img src="/vote/externallinkicon.jpg" width="15px" />
           Click here to visit the Election Status page.
@@ -43,7 +43,7 @@ export function SubmittedScreen({
       <h3>How to verify your vote:</h3>
       <p>
         Once the election closes and votes are unlocked, you can find yours on the{' '}
-        <Link as={`/election/${election_id}`} href="/election/[election_id]">
+        <Link as={`/election/${election_id}`} href="/election/[election_id]" legacyBehavior>
           <a style={{ color: 'black' }} target="_blank">
             Election Status page
           </a>

--- a/src/want/Headerbar.tsx
+++ b/src/want/Headerbar.tsx
@@ -4,7 +4,7 @@ import { darkBlue } from 'src/homepage/colors'
 export const Headerbar = () => (
   <header>
     <h3>
-      <Link href="/">
+      <Link href="/" legacyBehavior>
         <a className="logo">SIV</a>
       </Link>
     </h3>


### PR DESCRIPTION
- [x] This PR upgrades nextjs from v12 -> v13.
- [x] It also handles the breaking changes around `next/link`, with each usecase manually reviewed, some still using `legacyBehavior` where it was not trivial to adopt the new API.
- [x] It also handles the breaking changes around `next/image`, a few still using `next/legacy/image`.
- [x] `@next/font` was not used, so no changes needed there.
- [x] Dependency `next-transpile-modules` was removed, now that next13 supports its functionality out-of-the-box.
- [x] There were few stray `classNames` that got auto-sorted by Headwind.
- [x] Added a few `alt=` to Images that were missing them (the new `next/Image` makes it a required prop).