### PR TITLE
WIP: admin: Custom Email Subjects

### DIFF
--- a/pages/api/election/[election_id]/admin/load-admin.ts
+++ b/pages/api/election/[election_id]/admin/load-admin.ts
@@ -1,3 +1,4 @@
+import { buildSubject } from 'api/invite-voters'
 import { NextApiRequest, NextApiResponse } from 'next'
 import UAParser from 'ua-parser-js'
 
@@ -8,6 +9,7 @@ import { QueueLog } from './invite-voters'
 export type AdminData = {
   ballot_design?: string
   ballot_design_finalized?: boolean
+  custom_invitation_subject?: string
   custom_invitation_text?: string
   election_id?: string
   election_manager?: string
@@ -88,6 +90,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const {
     ballot_design,
     ballot_design_finalized,
+    custom_invitation_subject,
     custom_invitation_text,
     election_manager,
     election_title,
@@ -101,6 +104,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   } as {
     ballot_design?: string
     ballot_design_finalized?: boolean
+    custom_invitation_subject?: string
     custom_invitation_text?: string
     election_manager?: string
     election_title?: string
@@ -223,6 +227,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   return res.status(200).send({
     ballot_design,
     ballot_design_finalized,
+    custom_invitation_subject: custom_invitation_subject || buildSubject(election_title),
     custom_invitation_text,
     election_id,
     election_manager,

--- a/pages/api/election/[election_id]/admin/update-invitation-subject.ts
+++ b/pages/api/election/[election_id]/admin/update-invitation-subject.ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import { firebase } from '../../../_services'
+import { checkJwtOwnsElection } from '../../../validate-admin-jwt'
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { election_id } = req.query as { election_id: string }
+  const { custom_invitation_subject } = req.body
+
+  // Confirm they're a valid admin that created this election
+  const jwt = await checkJwtOwnsElection(req, res, election_id)
+  if (!jwt.valid) return
+
+  // Update the custom invitation text in the database
+  await firebase.firestore().collection('elections').doc(election_id).update({
+    custom_invitation_subject,
+  })
+
+  res.status(200).json({ message: 'Custom invitation subject updated' })
+}

--- a/src/admin/Voters/CustomInvitationEditor.tsx
+++ b/src/admin/Voters/CustomInvitationEditor.tsx
@@ -6,6 +6,7 @@ import { sha256 } from 'src/crypto/sha256'
 
 import { useUser } from '../auth'
 import { useStored } from '../useStored'
+import { CustomInvitationSubject } from './CustomInvitationSubject'
 
 const ToolbarButton = ({
   children,
@@ -116,96 +117,107 @@ export const CustomInvitationEditor = () => {
 
       {/* Editor Content */}
       {isExpanded && (
-        <div className="rounded border border-gray-300 border-solid shadow-sm">
-          {/* Toolbar */}
-          <div className="flex gap-1 justify-end p-2 bg-gray-50">
-            <ToolbarButton
-              className="font-semibold"
-              onClick={() => insertMarkdown('## ', '', 'Heading')}
-              tooltip="Heading"
-            >
-              H
-            </ToolbarButton>
-            <ToolbarButton className="font-bold" onClick={() => insertMarkdown('**', '**', 'bold text')} tooltip="Bold">
-              B
-            </ToolbarButton>
-            <ToolbarButton className="italic" onClick={() => insertMarkdown('*', '*', 'italic text')} tooltip="Italic">
-              I
-            </ToolbarButton>
-            <ToolbarButton
-              onClick={() => {
-                const url = prompt('Enter URL:')
-                if (url) insertMarkdown('[', `](${url})`, 'link text')
-              }}
-              tooltip="Link"
-            >
-              <LinkOutlined />
-            </ToolbarButton>
-            <ToolbarButton onClick={() => insertMarkdown('- ', '', 'list item')} tooltip="Bullet List">
-              <UnorderedListOutlined />
-            </ToolbarButton>
-            <ToolbarButton onClick={() => insertMarkdown('1. ', '', 'list item')} tooltip="Numbered List">
-              <OrderedListOutlined />
-            </ToolbarButton>
-          </div>
-
-          {/* Editor Area */}
-          <textarea
-            className="w-full p-4 min-h-[250px] resize-y outline-none bg-white text-gray-800 border-0 text-sm"
-            onChange={(e) => setContent(e.target.value)}
-            placeholder="Enter your custom invitation text..."
-            ref={textareaRef}
-            value={content}
-          />
-
-          {/* Footer */}
-          <div className="flex justify-between items-center px-4 py-2.5 text-sm border-t border-gray-200 bg-gray-50">
-            <div>
-              {isSaving && <span className="italic text-gray-400">saving...</span>}
-              {saved && <span className="italic text-green-700">saved.</span>}
-            </div>
-
-            <div>
-              <span className="text-gray-600">
-                <span className="text-xs">🔍</span> preview:{' '}
-              </span>
-              <a
-                className="text-blue-600 cursor-pointer hover:underline"
-                href={`/election/${election_id}/vote?auth=preview`}
-                rel="noreferrer"
-                target="_blank"
+        <>
+          <CustomInvitationSubject />
+          <div className="rounded border border-gray-300 border-solid shadow-sm">
+            {/* Toolbar */}
+            <div className="flex gap-1 justify-end p-2 bg-gray-50">
+              <ToolbarButton
+                className="font-semibold"
+                onClick={() => insertMarkdown('## ', '', 'Heading')}
+                tooltip="Heading"
               >
-                ballot
-              </a>
-              <span className="text-gray-500">, </span>
-              <a
-                className="text-blue-600 cursor-pointer hover:underline"
-                onClick={async (e) => {
-                  e.preventDefault()
-                  const confirmed = confirm(`Would you like to receive a mock email invitation at ${user?.email}?`)
-                  if (confirmed) {
-                    try {
-                      const response = await api(`election/${election_id}/admin/send-test-invitation`)
-
-                      if (response.ok) {
-                        const result = await response.json()
-                        alert(`Test invitation email sent successfully to ${result.recipient}`)
-                      } else {
-                        const error = await response.json()
-                        alert(`Failed to send test email: ${error.error || 'Unknown error'}`)
-                      }
-                    } catch (error) {
-                      console.error('Error sending test invitation:', error)
-                      alert('Failed to send test email. Please try again.')
-                    }
-                  }
+                H
+              </ToolbarButton>
+              <ToolbarButton
+                className="font-bold"
+                onClick={() => insertMarkdown('**', '**', 'bold text')}
+                tooltip="Bold"
+              >
+                B
+              </ToolbarButton>
+              <ToolbarButton
+                className="italic"
+                onClick={() => insertMarkdown('*', '*', 'italic text')}
+                tooltip="Italic"
+              >
+                I
+              </ToolbarButton>
+              <ToolbarButton
+                onClick={() => {
+                  const url = prompt('Enter URL:')
+                  if (url) insertMarkdown('[', `](${url})`, 'link text')
                 }}
+                tooltip="Link"
               >
-                email
-              </a>
+                <LinkOutlined />
+              </ToolbarButton>
+              <ToolbarButton onClick={() => insertMarkdown('- ', '', 'list item')} tooltip="Bullet List">
+                <UnorderedListOutlined />
+              </ToolbarButton>
+              <ToolbarButton onClick={() => insertMarkdown('1. ', '', 'list item')} tooltip="Numbered List">
+                <OrderedListOutlined />
+              </ToolbarButton>
+            </div>
+
+            {/* Editor Area */}
+            <textarea
+              className="w-full p-4 min-h-[250px] resize-y outline-none bg-white text-gray-800 border-0 text-sm"
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Enter your custom invitation text..."
+              ref={textareaRef}
+              value={content}
+            />
+
+            {/* Footer */}
+            <div className="flex justify-between items-center px-4 py-2.5 text-sm border-t border-gray-200 bg-gray-50">
+              <div>
+                {isSaving && <span className="italic text-gray-400">saving...</span>}
+                {saved && <span className="italic text-green-700">saved.</span>}
+              </div>
+
+              <div>
+                <span className="text-gray-600">
+                  <span className="text-xs">🔍</span> preview:{' '}
+                </span>
+                <a
+                  className="text-blue-600 cursor-pointer hover:underline"
+                  href={`/election/${election_id}/vote?auth=preview`}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  ballot
+                </a>
+                <span className="text-gray-500">, </span>
+                <a
+                  className="text-blue-600 cursor-pointer hover:underline"
+                  onClick={async (e) => {
+                    e.preventDefault()
+                    const confirmed = confirm(`Would you like to receive a mock email invitation at ${user?.email}?`)
+                    if (confirmed) {
+                      try {
+                        const response = await api(`election/${election_id}/admin/send-test-invitation`)
+
+                        if (response.ok) {
+                          const result = await response.json()
+                          alert(`Test invitation email sent successfully to ${result.recipient}`)
+                        } else {
+                          const error = await response.json()
+                          alert(`Failed to send test email: ${error.error || 'Unknown error'}`)
+                        }
+                      } catch (error) {
+                        console.error('Error sending test invitation:', error)
+                        alert('Failed to send test email. Please try again.')
+                      }
+                    }
+                  }}
+                >
+                  email
+                </a>
+              </div>
             </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   )
@@ -230,5 +242,6 @@ function useFeatureAccess(email: string) {
 const allowedUsers = {
   '1471fccb124bbf4': 's@A',
   '8044b24d7e96606': 'EHZ',
+  cb547b8468a4642: 'd@s',
   d12bc8d54668685: 'A@s',
 }

--- a/src/admin/Voters/CustomInvitationSubject.tsx
+++ b/src/admin/Voters/CustomInvitationSubject.tsx
@@ -1,20 +1,24 @@
-import { useState } from 'react'
+import { api } from 'src/api-helper'
 
-import { useStored } from '../useStored'
+import { revalidate, useStored } from '../useStored'
 
 export const CustomInvitationSubject = () => {
-  const { custom_invite_subject = 'Vote Invitation' } = useStored()
-  const [subject, setSubject] = useState(custom_invite_subject)
+  const { custom_invitation_subject = 'Loading...', election_id } = useStored()
 
   return (
     <div
       className="p-2 mb-1 rounded cursor-pointer hover:bg-gray-100"
-      onClick={() => {
-        const newSubject = prompt('Modify email subject:', subject)
-        if (newSubject) setSubject(newSubject)
+      onClick={async () => {
+        const newSubject = prompt('Modify email subject:', custom_invitation_subject)
+        if (!newSubject) return
+
+        await api(`election/${election_id}/admin/update-invitation-subject`, {
+          custom_invitation_subject: newSubject,
+        })
+        revalidate(election_id)
       }}
     >
-      <span className="opacity-50">Email subject:</span> {subject}
+      <span className="opacity-50">Email subject:</span> {custom_invitation_subject}
     </div>
   )
 }

--- a/src/admin/Voters/CustomInvitationSubject.tsx
+++ b/src/admin/Voters/CustomInvitationSubject.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+
+import { useStored } from '../useStored'
+
+export const CustomInvitationSubject = () => {
+  const { custom_invite_subject = 'Vote Invitation' } = useStored()
+  const [subject, setSubject] = useState(custom_invite_subject)
+
+  return (
+    <div
+      className="p-2 mb-1 rounded cursor-pointer hover:bg-gray-100"
+      onClick={() => {
+        const newSubject = prompt('Modify email subject:', subject)
+        if (newSubject) setSubject(newSubject)
+      }}
+    >
+      <span className="opacity-50">Email subject:</span> {subject}
+    </div>
+  )
+}


### PR DESCRIPTION
## Adds UI to admin panel:

<img width="754" height="202" alt="image" src="https://github.com/user-attachments/assets/804a8279-ea0d-409c-bda8-2cb02c98e169" />

### Hover over the subject line reveals its clickable:

<img width="464" height="163" alt="image" src="https://github.com/user-attachments/assets/b3763aaf-00f7-4b57-947a-f19a553e8e38" />

### Which opens a prompt to customize:

<img width="488" height="197" alt="image" src="https://github.com/user-attachments/assets/facb6777-3a93-4f18-b931-282102b4f1e2" />

### And after pressing save, it shows the new custom subject line:

<img width="334" height="120" alt="image" src="https://github.com/user-attachments/assets/10931131-0e1b-475d-b03d-f0cecdef0d59" />



-----

# Not Done yet:

- [ ] Actually using this new saved value to customize the sent emails' subject line: update `buildSubject()` to use it
- [ ] Making sure `check-voter-invite-status` doesn't break, because it currently depends on looking for a certain subject line