### PR TITLE
Allow admin to publish Who's Voted, by display name

### DIFF
--- a/pages/api/election/[election_id]/admin/add-voters.ts
+++ b/pages/api/election/[election_id]/admin/add-voters.ts
@@ -81,7 +81,7 @@ export async function addVotersToElection(new_voters: NewVoter[], election_id: s
           .set({
             added_at: new Date(),
             auth_token,
-            display_name: display_name_by_email[email],
+            ...(display_name_by_email[email] ? { display_name: display_name_by_email[email] } : {}),
             email,
             index: index + existing_voters.size,
           })

--- a/pages/api/election/[election_id]/admin/add-voters.ts
+++ b/pages/api/election/[election_id]/admin/add-voters.ts
@@ -4,11 +4,14 @@ import { firestore } from 'firebase-admin'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { generateAuthToken } from 'src/crypto/generate-auth-tokens'
 
+type NewVoter = string | { display_name?: string; email: string; }
+
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { new_voters } = req.body
   const { election_id } = req.query
 
   if (typeof election_id !== 'string') return res.status(401).json({ error: 'Missing election_id' })
+  if (!Array.isArray(new_voters)) return res.status(400).json({ error: 'new_voters must be an array' })
 
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
@@ -18,7 +21,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     already_added,
     duplicates_in_submission,
     unique_new_emails: unique_new_voters,
-  } = await addVotersToElection(new_voters, election_id)
+  } = await addVotersToElection(new_voters as NewVoter[], election_id)
 
   return res.status(201).json({
     all_duplicates: [...already_added, ...duplicates_in_submission],
@@ -32,20 +35,28 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
  * 2. Creates and stores unique auth tokens for each
  * 3. Updates election's num_voters tally
  */
-export async function addVotersToElection(new_voters: string[], election_id: string) {
+export async function addVotersToElection(new_voters: NewVoter[], election_id: string) {
   // Get existing voter from DB
   const electionDoc = firebase.firestore().collection('elections').doc(election_id)
   const loadVoters = electionDoc.collection('voters').get()
   const existing_voters = new Set()
-  ;(await loadVoters).docs.map((d) => existing_voters.add(d.data().email))
+    ; (await loadVoters).docs.map((d) => existing_voters.add(d.data().email))
 
   // Filter out duplicates within the submission
   const unique_in_submission = new Set<string>()
   const duplicates_in_submission: string[] = []
+  const display_name_by_email: Record<string, string | undefined> = {}
+
   for (const v of new_voters) {
-    if (!v) continue // Skip empties
-    if (unique_in_submission.has(v)) duplicates_in_submission.push(v)
-    else unique_in_submission.add(v)
+    const email = typeof v === 'string' ? v : v?.email
+    if (typeof email !== 'string') continue
+    const normalized = email.trim().toLowerCase()
+    if (!normalized) continue // Skip empties
+
+    if (typeof v === 'object' && v?.display_name) display_name_by_email[normalized] = v.display_name
+
+    if (unique_in_submission.has(normalized)) duplicates_in_submission.push(normalized)
+    else unique_in_submission.add(normalized)
   }
 
   // Filter out duplicates already added to the election
@@ -70,6 +81,7 @@ export async function addVotersToElection(new_voters: string[], election_id: str
           .set({
             added_at: new Date(),
             auth_token,
+            display_name: display_name_by_email[email],
             email,
             index: index + existing_voters.size,
           })

--- a/pages/api/election/[election_id]/admin/load-admin.ts
+++ b/pages/api/election/[election_id]/admin/load-admin.ts
@@ -16,6 +16,7 @@ export type AdminData = {
   esignature_requested?: boolean
   notified_unlocked?: number
   pending_votes?: PendingVote[]
+  public_whos_voted_snapshot?: Array<{ display_name?: string; has_voted: boolean }>
   stop_accepting_votes?: boolean
   threshold_public_key?: string
   trustees?: Trustee[]
@@ -97,6 +98,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     election_title,
     esignature_requested,
     notified_unlocked,
+    public_whos_voted_snapshot,
     stop_accepting_votes,
     threshold_public_key,
     voter_applications_allowed,
@@ -111,6 +113,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     election_title?: string
     esignature_requested?: boolean
     notified_unlocked?: number
+    public_whos_voted_snapshot?: Array<{ display_name?: string; has_voted: boolean }>
     stop_accepting_votes?: boolean
     threshold_public_key?: string
     voter_applications_allowed?: boolean
@@ -245,6 +248,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     esignature_requested,
     notified_unlocked,
     pending_votes,
+    public_whos_voted_snapshot,
     stop_accepting_votes,
     threshold_public_key,
     trustees,

--- a/pages/api/election/[election_id]/admin/load-admin.ts
+++ b/pages/api/election/[election_id]/admin/load-admin.ts
@@ -45,6 +45,7 @@ export type Trustee = {
 
 export type Voter = {
   auth_token: string
+  display_name?: string
   email: string
   esignature?: string
   esignature_review: ReviewLog[]
@@ -163,6 +164,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     const {
       additionalAuthInfo,
       auth_token,
+      display_name,
       email,
       esignature_review,
       first_name,
@@ -177,6 +179,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     } as {
       additionalAuthInfo?: Record<string, string>
       auth_token: string
+      display_name?: string
       email: string
       esignature_review: ReviewLog[]
       first_name: string
@@ -192,6 +195,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       {
         additionalAuthInfo,
         auth_token,
+        display_name,
         email,
         esignature: (votesByAuth[auth_token] || [])[1],
         esignature_review,

--- a/pages/api/election/[election_id]/admin/publish-whos-voted.ts
+++ b/pages/api/election/[election_id]/admin/publish-whos-voted.ts
@@ -1,0 +1,42 @@
+import { firebase } from 'api/_services'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import { checkJwtOwnsElection } from '../../../validate-admin-jwt'
+
+type PublicWhosVotedRow = { display_name?: string; has_voted: boolean }
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { election_id } = req.query as { election_id: string }
+
+  // Confirm they're a valid admin that created this election
+  const jwt = await checkJwtOwnsElection(req, res, election_id)
+  if (!jwt.valid) return
+
+  const electionDoc = firebase.firestore().collection('elections').doc(election_id)
+
+  // Load voters + votes + invalidations
+  const loadVoters = electionDoc.collection('voters').get()
+  const loadVotes = electionDoc.collection('votes').select('auth').get()
+  const loadInvalidatedVotes = electionDoc.collection('invalidated_votes').select('auth').get()
+
+  const votesByAuth = (await loadVotes).docs.reduce((acc, doc) => ({ ...acc, [doc.data().auth]: true }), {} as Record<
+    string,
+    true
+  >)
+
+  const invalidatedByAuth = (await loadInvalidatedVotes).docs.reduce(
+    (acc, doc) => ({ ...acc, [doc.data().auth]: true }),
+    {} as Record<string, true>,
+  )
+
+  const snapshot: PublicWhosVotedRow[] = (await loadVoters).docs.map((doc) => {
+    const { auth_token, display_name } = doc.data() as { auth_token?: string; display_name?: string }
+    const has_voted = !!(auth_token && (votesByAuth[auth_token] || invalidatedByAuth[auth_token]))
+    return { ...(display_name ? { display_name } : {}), has_voted }
+  })
+
+  await electionDoc.update({ public_whos_voted_snapshot: snapshot })
+
+  return res.status(201).json({ count: snapshot.length, message: 'Published whos voted snapshot' })
+}
+

--- a/pages/api/election/[election_id]/info.ts
+++ b/pages/api/election/[election_id]/info.ts
@@ -18,6 +18,7 @@ export type ElectionInfo = {
   paper_totals?: Record<string, number>
   paper_votes?: Record<string, string>[]
   privacy_protectors_statements?: string
+  public_whos_voted_snapshot?: Array<{ display_name?: string; has_voted: boolean }>
   skip_shuffle_proofs?: boolean
   submission_confirmation?: string
   threshold_public_key?: string
@@ -62,6 +63,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     paper_totals,
     paper_votes,
     privacy_protectors_statements,
+    public_whos_voted_snapshot,
     skip_shuffle_proofs,
     submission_confirmation,
     threshold_public_key,
@@ -84,6 +86,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     paper_totals,
     paper_votes: paper_votes ? JSON.parse(paper_votes) : undefined,
     privacy_protectors_statements,
+    public_whos_voted_snapshot,
     skip_shuffle_proofs,
     submission_confirmation,
     threshold_public_key,

--- a/src/admin/Voters/AddVoters.tsx
+++ b/src/admin/Voters/AddVoters.tsx
@@ -8,6 +8,7 @@ import { CustomEmailHeaderbar } from './CustomEmailHeaderbar'
 import { CustomInvitationEditor } from './CustomInvitationEditor'
 import { DuplicatesNotAdded } from './DuplicatesNotAdded'
 import { ExistingVoters } from './ExistingVoters'
+import { parseAddVoters } from './parseAddVoters'
 import { PrivacyProtectorsWarning } from './PrivacyProtectorsWarning'
 import { RequestEsignatures } from './RequestEsignatures'
 import { StopAcceptingVotes } from './StopAcceptingVotes'
@@ -34,9 +35,8 @@ export const AddVoters = () => {
       ) : (
         <SaveButton
           onPress={async () => {
-            const response = await api(`election/${election_id}/admin/add-voters`, {
-              new_voters: new_voters.split('\n').map((s) => s.trim().toLowerCase()),
-            })
+            const parsed = parseAddVoters(new_voters)
+            const response = await api(`election/${election_id}/admin/add-voters`, { new_voters: parsed })
 
             if (response.status === 201) {
               const data = await response.json()

--- a/src/admin/Voters/AddVoters.tsx
+++ b/src/admin/Voters/AddVoters.tsx
@@ -10,6 +10,7 @@ import { DuplicatesNotAdded } from './DuplicatesNotAdded'
 import { ExistingVoters } from './ExistingVoters'
 import { parseAddVoters } from './parseAddVoters'
 import { PrivacyProtectorsWarning } from './PrivacyProtectorsWarning'
+import { PublishWhosVoted } from './PublishWhosVoted'
 import { RequestEsignatures } from './RequestEsignatures'
 import { StopAcceptingVotes } from './StopAcceptingVotes'
 import { ToggleShareableLink } from './ToggleShareableLink'
@@ -56,6 +57,7 @@ export const AddVoters = () => {
       <ToggleShareableLink />
       <RequestEsignatures />
       <StopAcceptingVotes />
+      <PublishWhosVoted />
       <ExistingVoters />
     </div>
   )

--- a/src/admin/Voters/PublishWhosVoted.tsx
+++ b/src/admin/Voters/PublishWhosVoted.tsx
@@ -12,9 +12,9 @@ export const PublishWhosVoted = () => {
   const hasAnyDisplayName = !!voters?.some(({ display_name }) => !!display_name?.trim())
   if (!hasAnyDisplayName) return null
 
-  const currentVotes = voters?.filter(({ has_voted }) => has_voted).length
+  const currentVotes = voters?.filter(({ has_voted }) => has_voted).length || 0
   const publishedVotes = public_whos_voted_snapshot?.filter(({ has_voted }) => has_voted).length
-  const isUpToDate = typeof currentVotes === 'number' && typeof publishedVotes === 'number' && currentVotes === publishedVotes
+  const isUpToDate = typeof publishedVotes === 'number' && currentVotes === publishedVotes
   const disablePublish = publishing || isUpToDate
 
   return (
@@ -31,7 +31,6 @@ export const PublishWhosVoted = () => {
           setPublishing(false)
           if (response.status !== 201) throw await response.json()
           revalidate(election_id)
-          alert('Published.')
         }}
         type="button"
       >
@@ -50,6 +49,7 @@ export const PublishWhosVoted = () => {
             Published
           </a>{' '}
           {publishedVotes} {publishedVotes === 1 ? 'vote' : 'votes'}
+          {!isUpToDate && <>. {(currentVotes || 0) - publishedVotes} unpublished</>}
         </div>
       )}
     </section>

--- a/src/admin/Voters/PublishWhosVoted.tsx
+++ b/src/admin/Voters/PublishWhosVoted.tsx
@@ -1,0 +1,41 @@
+import { UsergroupAddOutlined } from '@ant-design/icons'
+import { useState } from 'react'
+
+import { api } from '../../api-helper'
+import { Spinner } from '../Spinner'
+import { revalidate, useStored } from '../useStored'
+
+export const PublishWhosVoted = () => {
+  const { election_id, voters } = useStored()
+  const [publishing, setPublishing] = useState(false)
+
+  const hasAnyDisplayName = !!voters?.some(({ display_name }) => !!display_name?.trim())
+  if (!hasAnyDisplayName) return null
+
+  return (
+    <section className="block mt-2 pt-0 p-1 ml-[-5px] pr-3">
+      <button
+        className="flex items-center px-3 py-2 bg-white rounded border-2 border-solid shadow-sm cursor-pointer border-black/15 hover:bg-neutral-50"
+        onClick={async () => {
+          if (!confirm('Publish the latest Who’s Voted list?')) return
+          setPublishing(true)
+          const response = await api(`election/${election_id}/admin/publish-whos-voted`, {})
+          setPublishing(false)
+          if (response.status !== 201) throw await response.json()
+          revalidate(election_id)
+          alert('Published.')
+        }}
+        type="button"
+      >
+        <UsergroupAddOutlined className="text-[18px] mr-1.5 relative top-px" />
+        Publish latest Who&apos;s Voted list
+        {publishing && (
+          <span className="ml-2">
+            <Spinner />
+          </span>
+        )}
+      </button>
+    </section>
+  )
+}
+

--- a/src/admin/Voters/PublishWhosVoted.tsx
+++ b/src/admin/Voters/PublishWhosVoted.tsx
@@ -12,13 +12,19 @@ export const PublishWhosVoted = () => {
   const hasAnyDisplayName = !!voters?.some(({ display_name }) => !!display_name?.trim())
   if (!hasAnyDisplayName) return null
 
+  const currentVotes = voters?.filter(({ has_voted }) => has_voted).length
   const publishedVotes = public_whos_voted_snapshot?.filter(({ has_voted }) => has_voted).length
+  const isUpToDate = typeof currentVotes === 'number' && typeof publishedVotes === 'number' && currentVotes === publishedVotes
+  const disablePublish = publishing || isUpToDate
 
   return (
     <section className="block mt-2 pt-0 p-1 ml-[-5px] pr-3">
       <button
-        className="flex items-center px-3 py-2 bg-white rounded border-2 border-solid shadow-sm cursor-pointer border-black/15 hover:bg-neutral-50"
+        className={`flex items-center px-3 py-2 bg-white rounded border-2 border-solid shadow-sm border-black/15 ${disablePublish ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-neutral-50'
+          }`}
         onClick={async () => {
+          if (publishing) return
+          if (isUpToDate) return alert('Already up to date.')
           if (!confirm('Publish the latest Who’s Voted list?')) return
           setPublishing(true)
           const response = await api(`election/${election_id}/admin/publish-whos-voted`, {})

--- a/src/admin/Voters/PublishWhosVoted.tsx
+++ b/src/admin/Voters/PublishWhosVoted.tsx
@@ -6,11 +6,13 @@ import { Spinner } from '../Spinner'
 import { revalidate, useStored } from '../useStored'
 
 export const PublishWhosVoted = () => {
-  const { election_id, voters } = useStored()
+  const { election_id, public_whos_voted_snapshot, voters } = useStored()
   const [publishing, setPublishing] = useState(false)
 
   const hasAnyDisplayName = !!voters?.some(({ display_name }) => !!display_name?.trim())
   if (!hasAnyDisplayName) return null
+
+  const publishedVotes = public_whos_voted_snapshot?.filter(({ has_voted }) => has_voted).length
 
   return (
     <section className="block mt-2 pt-0 p-1 ml-[-5px] pr-3">
@@ -35,6 +37,15 @@ export const PublishWhosVoted = () => {
           </span>
         )}
       </button>
+
+      {typeof publishedVotes === 'number' && (
+        <div className="text-[12px] opacity-70 mt-1 ml-1">
+          <a href={`/election/${election_id}`} rel="noreferrer" target="_blank">
+            Published
+          </a>{' '}
+          {publishedVotes} {publishedVotes === 1 ? 'vote' : 'votes'}
+        </div>
+      )}
     </section>
   )
 }

--- a/src/admin/Voters/ValidVotersTable.tsx
+++ b/src/admin/Voters/ValidVotersTable.tsx
@@ -39,6 +39,8 @@ export const ValidVotersTable = ({
       !invalidated && (!has_voted || !hide_voted) && (getStatus(esignature_review) !== 'approve' || !hide_approved),
   )
 
+  const shouldShowDisplayNameColumn = shown_voters.some(({ display_name }) => !!display_name?.trim())
+
   const shouldShowRegistrationColumns =
     // eslint-disable-next-line no-prototype-builtins
     shown_voters.some((voter) => voter.hasOwnProperty('is_email_verified'))
@@ -63,6 +65,7 @@ export const ValidVotersTable = ({
                 <th>last name</th>
               </>
             )}
+            {shouldShowDisplayNameColumn && <th>display name</th>}
             <th>email</th>
             {shouldShowRegistrationColumns && <th>email verified?</th>}
             <th className={hoverable} onClick={toggle_tokens}>
@@ -95,6 +98,7 @@ export const ValidVotersTable = ({
             (
               {
                 auth_token,
+                display_name,
                 email,
                 esignature,
                 esignature_review,
@@ -117,6 +121,7 @@ export const ValidVotersTable = ({
                     <td>{last_name}</td>
                   </>
                 )}
+                {shouldShowDisplayNameColumn && <td>{display_name}</td>}
 
                 <td>
                   <span className="flex justify-between group">

--- a/src/admin/Voters/parseAddVoters.test.ts
+++ b/src/admin/Voters/parseAddVoters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseAddVoters } from './parseAddVoters'
+
+describe('parseAddVoters', () => {
+  test('accepts one email per line', () => {
+    expect(parseAddVoters('a@b.com\nc@d.com')).toEqual([{ email: 'a@b.com' }, { email: 'c@d.com' }])
+  })
+
+  test('accepts fast placeholder emails like 1@1', () => {
+    expect(parseAddVoters('1@1\n2@1\n3@1')).toEqual([{ email: '1@1' }, { email: '2@1' }, { email: '3@1' }])
+  })
+
+  test('parses tab-separated two-column paste (email + display name)', () => {
+    expect(parseAddVoters('alice@email.com\tAlice Example')).toEqual([{ display_name: 'Alice Example', email: 'alice@email.com' }])
+  })
+
+  test('parses tab-separated two-column paste (display name + email)', () => {
+    expect(parseAddVoters('Alice Example\talice@email.com')).toEqual([{ display_name: 'Alice Example', email: 'alice@email.com' }])
+  })
+
+  test('tolerates a header row', () => {
+    expect(parseAddVoters('email\tname\nalice@email.com\tAlice Example')).toEqual([
+      { display_name: 'Alice Example', email: 'alice@email.com' },
+    ])
+  })
+
+  test('parses email-client recipient forms', () => {
+    expect(parseAddVoters('"John Doe" <john.doe@email.com>')).toEqual([
+      { display_name: 'John Doe', email: 'john.doe@email.com' },
+    ])
+    expect(parseAddVoters('Jane Doe <jane.doe@email.com>')).toEqual([
+      { display_name: 'Jane Doe', email: 'jane.doe@email.com' },
+    ])
+  })
+
+  test('splits comma-separated recipients on a single line', () => {
+    expect(parseAddVoters('"John Doe" <john.doe@email.com>, "Jane Doe" <jane.doe@email.com>')).toEqual([
+      { display_name: 'John Doe', email: 'john.doe@email.com' },
+      { display_name: 'Jane Doe', email: 'jane.doe@email.com' },
+    ])
+  })
+
+  test('dedupes by normalized email', () => {
+    expect(parseAddVoters('A@B.com\na@b.com')).toEqual([{ email: 'a@b.com' }])
+  })
+})
+

--- a/src/admin/Voters/parseAddVoters.ts
+++ b/src/admin/Voters/parseAddVoters.ts
@@ -1,0 +1,146 @@
+import { validate as validateEmail } from 'email-validator'
+
+export type ParsedVoter = { display_name?: string; email: string; }
+
+/**
+ * Parse admin-pasted voter input into structured records.
+ *
+ * Supported input styles:
+ * - One per line: `email`
+ * - Two columns (tab or comma): `email<TAB>Display Name` or `Display Name<TAB>email`
+ * - Email-client recipients:
+ *   - `"John Doe" <john@x.com>`
+ *   - `John Doe <john@x.com>`
+ *   - Comma-separated recipients on one line (splits on commas outside quotes/angle brackets)
+ *
+ * Notes:
+ * - We intentionally accept fast "fake" emails like `1@1` (loose detection),
+ *   but prefer strict validation when it’s clearly available.
+ */
+export function parseAddVoters(input: string): ParsedVoter[] {
+  const results: ParsedVoter[] = []
+  const seen = new Set<string>()
+
+  for (const rawLine of input.split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+
+    // Split a line into multiple recipients if it's email-client style.
+    for (const part of splitOutsideQuotesAndAngles(line, ',')) {
+      const rec = parseOneRecipient(part.trim())
+      if (!rec) continue
+
+      // Dedupe by normalized email
+      const email = normalizeEmail(rec.email)
+      if (!email) continue
+      if (seen.has(email)) continue
+      seen.add(email)
+
+      results.push({ display_name: rec.display_name, email })
+    }
+  }
+
+  return results
+}
+
+function cleanupDisplayName(s: string): string {
+  const t = s.trim()
+  if (!t) return ''
+  // Strip leading/trailing quotes and surrounding punctuation.
+  return t.replace(/^[\s"'“”]+/, '').replace(/[\s"'“”]+$/, '').replace(/^[,;]+|[,;]+$/g, '').trim()
+}
+
+function isLooselyEmailLike(s: string): boolean {
+  // Accept "1@1" etc (no spaces, one '@', non-empty sides).
+  const t = s.trim()
+  if (!t || /\s/.test(t)) return false
+  const at = t.indexOf('@')
+  return at > 0 && at === t.lastIndexOf('@') && at < t.length - 1
+}
+
+function looksLikeHeader(tokens: string[]): boolean {
+  const lower = tokens.map((t) => t.toLowerCase())
+  const hasEmailWord = lower.some((t) => t.includes('email'))
+  const hasNameWord = lower.some((t) => t.includes('name') || t.includes('display'))
+  const hasValidEmail = tokens.some((t) => validateEmail(t) || isLooselyEmailLike(t))
+  return (hasEmailWord || hasNameWord) && !hasValidEmail
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+function parseOneRecipient(s: string): null | ParsedVoter {
+  if (!s) return null
+
+  // Handle `Name <email>` (with or without quotes)
+  const angleMatch = s.match(/^(.*)<\s*([^>]+)\s*>\s*$/)
+  if (angleMatch) {
+    const maybeName = cleanupDisplayName(angleMatch[1])
+    const maybeEmail = angleMatch[2].trim()
+    const email = pickEmailToken([maybeEmail]) || maybeEmail
+    if (!isLooselyEmailLike(email)) return null
+    return { display_name: maybeName || undefined, email }
+  }
+
+  // Two-column style: tab or comma separated.
+  // Prefer tab if present (google sheets paste).
+  const delim = s.includes('\t') ? '\t' : s.includes(',') ? ',' : null
+  if (delim) {
+    const tokens = s
+      .split(delim)
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // If it looks like a header row, skip it.
+    if (looksLikeHeader(tokens)) return null
+
+    if (tokens.length === 1) {
+      const email = tokens[0]
+      return isLooselyEmailLike(email) ? { email } : null
+    }
+
+    const email = pickEmailToken(tokens)
+    if (!email) return null
+    const display = tokens.filter((t) => t !== email).join(' ').trim()
+    return { display_name: cleanupDisplayName(display) || undefined, email }
+  }
+
+  // Plain: just an email token
+  return isLooselyEmailLike(s) ? { email: s } : null
+}
+
+function pickEmailToken(tokens: string[]): null | string {
+  // Prefer strict validation when possible.
+  const strict = tokens.find((t) => validateEmail(t))
+  if (strict) return strict
+
+  // Otherwise accept loose emails like `1@1`.
+  return tokens.find((t) => isLooselyEmailLike(t)) || null
+}
+
+function splitOutsideQuotesAndAngles(s: string, delimiter: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let inQuotes = false
+  let angleDepth = 0
+
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (ch === '"') inQuotes = !inQuotes
+    if (!inQuotes) {
+      if (ch === '<') angleDepth++
+      if (ch === '>' && angleDepth > 0) angleDepth--
+    }
+
+    if (ch === delimiter && !inQuotes && angleDepth === 0) {
+      out.push(cur)
+      cur = ''
+      continue
+    }
+    cur += ch
+  }
+
+  out.push(cur)
+  return out
+}

--- a/src/status/ElectionStatusPage.tsx
+++ b/src/status/ElectionStatusPage.tsx
@@ -12,6 +12,7 @@ import { OnlyMixnet } from './OnlyMixnet'
 import { PaperBallots } from './PaperBallots'
 import { Totals } from './Totals'
 import { useElectionInfo } from './use-election-info'
+import { WhosVoted } from './WhosVoted'
 
 export const ElectionStatusPage = (): JSX.Element => {
   const { election_id, hide_tallies } = useRouter().query as { election_id: string; hide_tallies?: string }
@@ -72,6 +73,7 @@ export const ElectionStatusPage = (): JSX.Element => {
           <br />
           <DecryptedVotes />
           <PaperBallots />
+          <WhosVoted />
           <br />
 
           {!hideEncryptedVotes.includes(election_id) && (

--- a/src/status/WhosVoted.tsx
+++ b/src/status/WhosVoted.tsx
@@ -1,0 +1,41 @@
+import { useElectionInfo } from './use-election-info'
+
+const missing = '(no name)'
+
+export const WhosVoted = () => {
+  const { public_whos_voted_snapshot } = useElectionInfo()
+  if (!public_whos_voted_snapshot?.length) return null
+
+  const rows = [...public_whos_voted_snapshot]
+    .map((r) => ({ ...r, display_name: r.display_name?.trim() || '' }))
+    .sort((a, b) => {
+      const an = a.display_name ? a.display_name.toLowerCase() : '\uffff'
+      const bn = b.display_name ? b.display_name.toLowerCase() : '\uffff'
+      return an.localeCompare(bn)
+    })
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-[0_2px_2px_hsla(0,0%,50%,0.333),0_4px_4px_hsla(0,0%,50%,0.333),0_6px_6px_hsla(0,0%,50%,0.333)] mt-6">
+      <h3 className="mt-0 mb-2">Who&apos;s Voted</h3>
+      <table className="block overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px] pb-2">
+        <thead>
+          <tr className="bg-[#f9f9f9] text-[11px]">
+            <th>#</th>
+            <th>display name</th>
+            <th>voted</th>
+          </tr>
+        </thead>
+        <tbody className="[&_td]:whitespace-nowrap bg-white">
+          {rows.map(({ display_name, has_voted }, index) => (
+            <tr key={`${display_name || missing}-${index}`}>
+              <td>{index + 1}</td>
+              <td>{display_name || missing}</td>
+              <td className="font-bold text-center">{has_voted ? '✓' : ''}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+


### PR DESCRIPTION
### We now allow pasting in two-column voter lists, with email + display name (in either order).

The old input styles should also continue to work as before.

This PR includes a nice unit test file for all the various formats accepted: [`parseAddVoters.test.ts`](https://github.com/siv-org/siv/pull/295/files#diff-5ee90f6fa91246e6179cdecdab28bbf547bcc540ca1dc9945429cffa2dd5fffa)

(As a nice bonus we also now allow pasting in `"Alice" <alice@email.com>, "Bob" <bob@email.com>` style lists, eg copy-pasted from an email groupthread. )

### If the admin adds at least one display name, those are now shown in their dashboard, along with this new button:

<img width="502" height="253" alt="image" src="https://github.com/user-attachments/assets/aa557d1c-8cad-4ade-b7af-34c67a513f1a" />

### Hitting the button manually builds a new cached list of who's voted, and publishes it on the public election status page:

<img width="584" height="725" alt="image" src="https://github.com/user-attachments/assets/0e52e01d-d302-4d1d-8819-4f44d72458fc" />

1. This list is intentionally *alphabetized*, not chronological like the encrypted votes list, in part to avoid the linkage between voters and their cipher texts.
2. It does *not* update in real time. That's also to avoid leaking voter-ciphertext connections via timing. Right now admin has to hit the button again to re-trigger a new publish.
  - [ ] this is not yet currently well-communicated on the election status page itself. could improve.

3. admin's button intentionally says how many have been published, and how many are missing if there have been new votes since the last publish.
4. the list is intentionally just a plaintext array on the main election doc, so *zero* extra reads for voters accessing the page (They were already pulling the election doc on every page load, eg. for the election title)
