### PR TITLE
Fix Bug: Filter & Send invitations

### DIFF
--- a/src/admin/Voters/CheckboxCell.tsx
+++ b/src/admin/Voters/CheckboxCell.tsx
@@ -17,8 +17,7 @@ export const CheckboxCell = ({
   pressing_shift: boolean
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
-  // Indices (into checked[]) of the rows currently visible after filtering.
-  // When omitted, every index between the two clicked rows is toggled.
+  // Indices (into checked[]) of the rows currently visible after filtering. When omitted, every index between the two clicked rows is toggled.
   visible_indices?: number[]
 }) => {
   return (
@@ -27,8 +26,7 @@ export const CheckboxCell = ({
       onClick={() => {
         const new_checked = [...checked]
         if (pressing_shift && last_selected !== undefined) {
-          // If they're holding shift, set all *visible* rows between last_selected and this index
-          // to !checked[index], so hidden (e.g. already-voted) rows in-between aren't touched
+          // If they're holding shift, set all *visible* rows between last_selected and this index to !checked[index], so hidden (e.g. already-voted) rows in-between aren't touched
           const [lo, hi] = [Math.min(index, last_selected), Math.max(index, last_selected)]
           const range = visible_indices?.filter((i) => i >= lo && i <= hi) ?? range_of(lo, hi)
           range.forEach((i) => (new_checked[i] = !checked[index]))
@@ -54,8 +52,7 @@ export const CheckboxHeaderCell = ({
   checked: boolean[]
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
-  // Indices (into checked[]) of the rows currently visible after filtering.
-  // When omitted, all rows are toggled.
+  // Indices (into checked[]) of the rows currently visible after filtering.When omitted, all rows are toggled.
   visible_indices?: number[]
 }) => {
   const targets = visible_indices ?? range_of(0, checked.length - 1)
@@ -66,8 +63,7 @@ export const CheckboxHeaderCell = ({
         checked={targets.length > 0 && targets.every((i) => checked[i])}
         className="cursor-pointer"
         onChange={(event) => {
-          // "Select All" means exactly the visible set: clear everything, then
-          // (when checking) select only the currently visible rows
+          // "Select All" means exactly the visible set: clear everything, then(when checking) select only the currently visible rows
           const new_checked = new Array(checked.length).fill(false)
           if (event.target.checked) targets.forEach((i) => (new_checked[i] = true))
           set_checked(new_checked)

--- a/src/admin/Voters/CheckboxCell.tsx
+++ b/src/admin/Voters/CheckboxCell.tsx
@@ -1,5 +1,7 @@
 export const hoverable = `cursor-pointer hover:bg-[#f2f2f2]`
 
+const range_of = (lo: number, hi: number) => Array.from({ length: hi - lo + 1 }, (_, i) => lo + i)
+
 export const CheckboxCell = ({
   checked,
   index,
@@ -15,8 +17,9 @@ export const CheckboxCell = ({
   pressing_shift: boolean
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
-  // Indices (into checked[]) of the rows currently visible after filtering
-  visible_indices: number[]
+  // Indices (into checked[]) of the rows currently visible after filtering.
+  // When omitted, every index between the two clicked rows is toggled.
+  visible_indices?: number[]
 }) => {
   return (
     <td
@@ -27,9 +30,8 @@ export const CheckboxCell = ({
           // If they're holding shift, set all *visible* rows between last_selected and this index
           // to !checked[index], so hidden (e.g. already-voted) rows in-between aren't touched
           const [lo, hi] = [Math.min(index, last_selected), Math.max(index, last_selected)]
-          visible_indices.forEach((i) => {
-            if (i >= lo && i <= hi) new_checked[i] = !checked[index]
-          })
+          const range = visible_indices?.filter((i) => i >= lo && i <= hi) ?? range_of(lo, hi)
+          range.forEach((i) => (new_checked[i] = !checked[index]))
         } else {
           new_checked[index] = !checked[index]
         }
@@ -52,23 +54,27 @@ export const CheckboxHeaderCell = ({
   checked: boolean[]
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
-  // Indices (into checked[]) of the rows currently visible after filtering
-  visible_indices: number[]
-}) => (
-  <th>
-    <input
-      // Only reflect as checked when every visible row is selected
-      checked={visible_indices.length > 0 && visible_indices.every((i) => checked[i])}
-      className="cursor-pointer"
-      onChange={(event) => {
-        // Only toggle the currently visible rows, leaving hidden rows untouched
-        const new_checked = [...checked]
-        visible_indices.forEach((i) => (new_checked[i] = event.target.checked))
-        set_checked(new_checked)
-        set_last_selected(undefined)
-      }}
-      readOnly
-      type="checkbox"
-    />
-  </th>
-)
+  // Indices (into checked[]) of the rows currently visible after filtering.
+  // When omitted, all rows are toggled.
+  visible_indices?: number[]
+}) => {
+  const targets = visible_indices ?? range_of(0, checked.length - 1)
+  return (
+    <th>
+      <input
+        // Only reflect as checked when every visible row is selected
+        checked={targets.length > 0 && targets.every((i) => checked[i])}
+        className="cursor-pointer"
+        onChange={(event) => {
+          // Only toggle the currently visible rows, leaving hidden rows untouched
+          const new_checked = [...checked]
+          targets.forEach((i) => (new_checked[i] = event.target.checked))
+          set_checked(new_checked)
+          set_last_selected(undefined)
+        }}
+        readOnly
+        type="checkbox"
+      />
+    </th>
+  )
+}

--- a/src/admin/Voters/CheckboxCell.tsx
+++ b/src/admin/Voters/CheckboxCell.tsx
@@ -7,6 +7,7 @@ export const CheckboxCell = ({
   pressing_shift,
   set_checked,
   set_last_selected,
+  visible_indices,
 }: {
   checked: boolean[]
   index: number
@@ -14,6 +15,8 @@ export const CheckboxCell = ({
   pressing_shift: boolean
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
+  // Indices (into checked[]) of the rows currently visible after filtering
+  visible_indices: number[]
 }) => {
   return (
     <td
@@ -21,10 +24,12 @@ export const CheckboxCell = ({
       onClick={() => {
         const new_checked = [...checked]
         if (pressing_shift && last_selected !== undefined) {
-          // If they're holding shift, set all between last_selected and this index to !checked[index]
-          for (let i = Math.min(index, last_selected); i <= Math.max(index, last_selected); i += 1) {
-            new_checked[i] = !checked[index]
-          }
+          // If they're holding shift, set all *visible* rows between last_selected and this index
+          // to !checked[index], so hidden (e.g. already-voted) rows in-between aren't touched
+          const [lo, hi] = [Math.min(index, last_selected), Math.max(index, last_selected)]
+          visible_indices.forEach((i) => {
+            if (i >= lo && i <= hi) new_checked[i] = !checked[index]
+          })
         } else {
           new_checked[index] = !checked[index]
         }

--- a/src/admin/Voters/CheckboxCell.tsx
+++ b/src/admin/Voters/CheckboxCell.tsx
@@ -66,9 +66,10 @@ export const CheckboxHeaderCell = ({
         checked={targets.length > 0 && targets.every((i) => checked[i])}
         className="cursor-pointer"
         onChange={(event) => {
-          // Only toggle the currently visible rows, leaving hidden rows untouched
-          const new_checked = [...checked]
-          targets.forEach((i) => (new_checked[i] = event.target.checked))
+          // "Select All" means exactly the visible set: clear everything, then
+          // (when checking) select only the currently visible rows
+          const new_checked = new Array(checked.length).fill(false)
+          if (event.target.checked) targets.forEach((i) => (new_checked[i] = true))
           set_checked(new_checked)
           set_last_selected(undefined)
         }}

--- a/src/admin/Voters/CheckboxCell.tsx
+++ b/src/admin/Voters/CheckboxCell.tsx
@@ -42,20 +42,27 @@ export const CheckboxHeaderCell = ({
   checked,
   set_checked,
   set_last_selected,
+  visible_indices,
 }: {
   checked: boolean[]
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
+  // Indices (into checked[]) of the rows currently visible after filtering
+  visible_indices: number[]
 }) => (
   <th>
     <input
+      // Only reflect as checked when every visible row is selected
+      checked={visible_indices.length > 0 && visible_indices.every((i) => checked[i])}
       className="cursor-pointer"
       onChange={(event) => {
+        // Only toggle the currently visible rows, leaving hidden rows untouched
         const new_checked = [...checked]
-        new_checked.fill(event.target.checked)
+        visible_indices.forEach((i) => (new_checked[i] = event.target.checked))
         set_checked(new_checked)
         set_last_selected(undefined)
       }}
+      readOnly
       type="checkbox"
     />
   </th>

--- a/src/admin/Voters/CheckboxCell.tsx
+++ b/src/admin/Voters/CheckboxCell.tsx
@@ -17,7 +17,6 @@ export const CheckboxCell = ({
   pressing_shift: boolean
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
-  // Indices (into checked[]) of the rows currently visible after filtering. When omitted, every index between the two clicked rows is toggled.
   visible_indices?: number[]
 }) => {
   return (
@@ -52,7 +51,6 @@ export const CheckboxHeaderCell = ({
   checked: boolean[]
   set_checked: (checked: boolean[]) => void
   set_last_selected: (index?: number) => void
-  // Indices (into checked[]) of the rows currently visible after filtering.When omitted, all rows are toggled.
   visible_indices?: number[]
 }) => {
   const targets = visible_indices ?? range_of(0, checked.length - 1)

--- a/src/admin/Voters/ValidVotersTable.tsx
+++ b/src/admin/Voters/ValidVotersTable.tsx
@@ -61,7 +61,9 @@ export const ValidVotersTable = ({
       <table className="block w-full mt-1 pb-3 overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px]">
         <thead>
           <tr className="bg-[#f9f9f9] text-[11px]">
-            <CheckboxHeaderCell {...{ checked, set_checked, set_last_selected }} />
+            <CheckboxHeaderCell
+              {...{ checked, set_checked, set_last_selected, visible_indices: shown_voters.map((v) => v.validIndex) }}
+            />
             <th>#</th>
             {shouldShowRegistrationColumns && (
               <>

--- a/src/admin/Voters/ValidVotersTable.tsx
+++ b/src/admin/Voters/ValidVotersTable.tsx
@@ -43,6 +43,8 @@ export const ValidVotersTable = ({
         (!has_voted || !hide_voted) && (getStatus(esignature_review) !== 'approve' || !hide_approved),
     )
 
+  const visible_indices = shown_voters.map((v) => v.validIndex)
+
   const shouldShowDisplayNameColumn = shown_voters.some(({ display_name }) => !!display_name?.trim())
 
   const shouldShowRegistrationColumns =
@@ -61,9 +63,7 @@ export const ValidVotersTable = ({
       <table className="block w-full mt-1 pb-3 overflow-auto border-collapse [&_tr>*]:[border:1px_solid_#ccc] [&_tr>*]:px-2.5 [&_tr>*]:py-[3px]">
         <thead>
           <tr className="bg-[#f9f9f9] text-[11px]">
-            <CheckboxHeaderCell
-              {...{ checked, set_checked, set_last_selected, visible_indices: shown_voters.map((v) => v.validIndex) }}
-            />
+            <CheckboxHeaderCell {...{ checked, set_checked, set_last_selected, visible_indices }} />
             <th>#</th>
             {shouldShowRegistrationColumns && (
               <>
@@ -120,7 +120,15 @@ export const ValidVotersTable = ({
             ) => (
               <tr className={`${checked[validIndex] && 'bg-[#f1f1f1]'}`} key={email}>
                 <CheckboxCell
-                  {...{ checked, index: validIndex, last_selected, pressing_shift, set_checked, set_last_selected }}
+                  {...{
+                    checked,
+                    index: validIndex,
+                    last_selected,
+                    pressing_shift,
+                    set_checked,
+                    set_last_selected,
+                    visible_indices,
+                  }}
                 />
 
                 <td>{displayIndex + 1}</td>


### PR DESCRIPTION
## TL;DR

Selecting voters ignored the Hide Voted filter: both "Select All" and shift-click range selection grabbed already-voted voters, so re-sent invitations could go to people who'd already voted.

Fix: the checkbox components now take an optional visible_indices prop and only select the currently visible (filtered) rows. ValidVotersTable passes the filtered indices; tables without a filter (e.g. VotesAwaitingApprovalTable) omit it and keep their original select-everything behavior.

## Problem
Voter selection ignores the "Hide Voted" filter

### Re-creating problem
In the admin panel, after starting an election and adding voters by email, an admin often wants to re-send the vote invitation to only the people who haven't voted yet. To do this, they click Hide Voted, which filters the list down to just the not-yet-voted voters.

Two selection actions failed to respect this filter and selected already-voted voters anyway:
1. Select All — With "Hide Voted" active, clicking the header "Select All" checkbox selected every voter, including the hidden ones who had already voted. 

_It should_ only select the voters currently visible in the filtered list.

2. Shift-click range select — With "Hide Voted" active, clicking the first visible voter and then shift-clicking a later one selected every voter in between by their underlying position — including the hidden, already-voted voters sitting between them.

_It should_ only select the visible (not-yet-voted) voters within that range.

Both bugs meant invitations could be re-sent to people who had already voted.

## Solution
Both selection actions now operate on the set of visible rows rather than the full voter list.

**1)** The "Select All" header checkbox now only acts on the currently visible rows.

What changed:
- CheckboxHeaderCell (src/admin/Voters/CheckboxCell.tsx) now takes a visible_indices prop. On toggle, it only sets those indices in the checked array, leaving hidden (e.g. already-voted) voters untouched. As a bonus, the checkbox now visually reflects whether all visible rows are selected.

- ValidVotersTable (src/admin/Voters/ValidVotersTable.tsx) passes shown_voters.map((v) => v.validIndex) as the visible indices, which is exactly the filtered list driven by hide_voted/hide_approved.

So now when you click "Hide Voted" and then "Select All", only the not-yet-voted voters get selected, and "Send Invitations" will target just them.

**_Note: because hidden rows are left as-is, if you had manually checked someone, then hid them, "Select All" won't deselect them. We might want that "Select All" to mean "exactly the visible set and nothing else," & change it to clear all, then select only the visible ones._**



**2)** Shift-click range selection now only toggles the visible rows.

What changed:
- CheckboxCell (src/admin/Voters/CheckboxCell.tsx) now takes visible_indices. Instead of looping over every index between the two clicked rows (which swept up hidden voted voters), it iterates only the visible indices and toggles those that fall within the clicked range. Hidden rows in between are left untouched.

- ValidVotersTable computes visible_indices once and passes it to both the header and per-row checkboxes. So now: Hide Voted → click first → shift-click last selects only the not-yet-voted voters in that visible range.

**_Note:_** visible_indices is an optional prop. When it's omitted, the components fall back to their original behavior — Select All toggles every row, and shift-click selects the full contiguous range. This keeps the shared VotesAwaitingApprovalTable (which has no "Hide Voted" filter) working exactly as before, with no caller changes required.