### PR TITLE
admin: Warn before inviting already-voted voters

### DIFF
--- a/src/admin/Voters/SendInvitationsButton.tsx
+++ b/src/admin/Voters/SendInvitationsButton.tsx
@@ -29,11 +29,26 @@ export const SendInvitationsButton = ({
         if (!ballot_design_finalized) return alert('You need to Finalize a Ballot Design first.')
         if (!threshold_public_key) return alert('You need to finish setting the election Privacy Protectors first.')
 
-        toggle_sending()
         const voters_to_invite = checked.reduce((acc: string[], is_checked, index) => {
           if (is_checked) acc.push(valid_voters[index].email)
           return acc
         }, [])
+
+        // Warn if any selected voters have already cast a vote (e.g. accidentally selected while hidden)
+        const already_voted = checked.reduce((acc: string[], is_checked, index) => {
+          if (is_checked && valid_voters[index].has_voted) acc.push(valid_voters[index].email)
+          return acc
+        }, [])
+        if (already_voted.length) {
+          const preview = already_voted.slice(0, 5).join(', ')
+          const more = already_voted.length > 5 ? `, and ${already_voted.length - 5} more` : ''
+          const warning =
+            `Heads up: ${already_voted.length} of the selected voter${already_voted.length === 1 ? ' has' : 's have'} ` +
+            `already cast a vote (${preview}${more}).\n\nAre you sure you want to send them another invitation?`
+          if (!confirm(warning)) return
+        }
+
+        toggle_sending()
 
         // Revalidate every second
         const revalidate_interval = setInterval(() => revalidate(election_id), 1000)


### PR DESCRIPTION
Now SendInvitationsButton checks for already-voted voters in the selection before sending, and if it finds any, shows a confirm dialog:

> Heads up: 3 of the selected voters have already cast a vote ([a@x.com](mailto:a@x.com), [b@x.com](mailto:b@x.com), [c@x.com](mailto:c@x.com)).
>
> Are you sure you want to send them another invitation?

It previews up to 5 emails (with "and N more"), handles singular/plural, and aborts the send if the admin cancels. This is the backstop that catches accidentally-selected voted voters no matter how they got selected.