### PR TITLE
/admin/ballot-design: Begin adding upload feature

### DIFF
--- a/pages/api/_services.ts
+++ b/pages/api/_services.ts
@@ -21,8 +21,14 @@ export const firebase = !Firebase.apps.length
         projectId: FIREBASE_PROJECT_ID,
       }),
       databaseURL: FIREBASE_DATABASE_URL || 'https://siv-demo.firebaseio.com',
+      storageBucket: `${FIREBASE_PROJECT_ID || 'siv-demo'}.appspot.com`,
     })
   : Firebase.app()
+
+const firebaseStorageBucketName = () =>
+  process.env.FIREBASE_STORAGE_BUCKET || `${process.env.FIREBASE_PROJECT_ID || 'siv-demo'}.appspot.com`
+
+export const storageBucket = () => firebase.storage().bucket(firebaseStorageBucketName())
 
 type SerializedTimestamp = { _seconds: number }
 /** `new Date()`, which Firebase will automatically serialize into `{ _seconds: number }` */

--- a/pages/api/election/[election_id]/admin/upload-ballot-design.ts
+++ b/pages/api/election/[election_id]/admin/upload-ballot-design.ts
@@ -8,11 +8,6 @@ const MAX_BYTES = 4 * 1024 * 1024
 
 export const config = { api: { bodyParser: { sizeLimit: '5mb' } } }
 
-function sanitizeFilename(filename: string) {
-  const base = filename.split(/[/\\]/).pop() || 'upload'
-  return base.replace(/[^\w.\-()+ ]/g, '_').slice(0, 200) || 'upload'
-}
-
 function detectFormat(buffer: Buffer, filename: string): 'siv_json' | undefined {
   const looksJson = filename.toLowerCase().endsWith('.json') || buffer[0] === 0x7b || buffer[0] === 0x5b
   if (!looksJson) return undefined
@@ -24,6 +19,11 @@ function detectFormat(buffer: Buffer, filename: string): 'siv_json' | undefined 
     // not valid SIV JSON
   }
   return undefined
+}
+
+function sanitizeFilename(filename: string) {
+  const base = filename.split(/[/\\]/).pop() || 'upload'
+  return base.replace(/[^\w.\-()+ ]/g, '_').slice(0, 200) || 'upload'
 }
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {

--- a/pages/api/election/[election_id]/admin/upload-ballot-design.ts
+++ b/pages/api/election/[election_id]/admin/upload-ballot-design.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { check_for_fatal_ballot_errors } from 'src/admin/BallotDesign/check_for_ballot_errors'
 
-import { firebase, pushover } from '../../../_services'
+import { firebase, pushover, storageBucket } from '../../../_services'
 import { checkJwtOwnsElection } from '../../../validate-admin-jwt'
 
 const MAX_BYTES = 4 * 1024 * 1024
@@ -54,13 +54,18 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const uploadId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const storagePath = `ballot-design-uploads/${election_id}/${uploadId}-${safeFilename}`
 
-  await firebase
-    .storage()
-    .bucket()
-    .file(storagePath)
-    .save(buffer, {
-      metadata: { contentType: typeof mime_type === 'string' ? mime_type : 'application/octet-stream' },
-    })
+  try {
+    await storageBucket()
+      .file(storagePath)
+      .save(buffer, {
+        metadata: { contentType: typeof mime_type === 'string' ? mime_type : 'application/octet-stream' },
+      })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error('ballot design upload: storage save failed', message)
+    await pushover('Ballot design upload: Storage failed', `${election_id}\n${safeFilename}\n${message}`)
+    return res.status(503).json({ error: `File storage failed: ${message}` })
+  }
 
   const format = detectFormat(buffer, safeFilename)
 

--- a/pages/api/election/[election_id]/admin/upload-ballot-design.ts
+++ b/pages/api/election/[election_id]/admin/upload-ballot-design.ts
@@ -1,0 +1,89 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { check_for_fatal_ballot_errors } from 'src/admin/BallotDesign/check_for_ballot_errors'
+
+import { firebase, pushover } from '../../../_services'
+import { checkJwtOwnsElection } from '../../../validate-admin-jwt'
+
+const MAX_BYTES = 4 * 1024 * 1024
+
+export const config = { api: { bodyParser: { sizeLimit: '5mb' } } }
+
+function sanitizeFilename(filename: string) {
+  const base = filename.split(/[/\\]/).pop() || 'upload'
+  return base.replace(/[^\w.\-()+ ]/g, '_').slice(0, 200) || 'upload'
+}
+
+function detectFormat(buffer: Buffer, filename: string): 'siv_json' | undefined {
+  const looksJson = filename.toLowerCase().endsWith('.json') || buffer[0] === 0x7b || buffer[0] === 0x5b
+  if (!looksJson) return undefined
+
+  try {
+    const text = buffer.toString('utf8')
+    if (!check_for_fatal_ballot_errors(text)) return 'siv_json'
+  } catch {
+    // not valid SIV JSON
+  }
+  return undefined
+}
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  const { content_base64, filename, mime_type } = req.body
+  const { election_id } = req.query as { election_id: string }
+
+  const jwt = await checkJwtOwnsElection(req, res, election_id)
+  if (!jwt.valid) return
+  if (jwt.ballot_design_finalized) return res.status(401).json({ error: 'Ballot already finalized' })
+
+  if (typeof filename !== 'string' || !filename.trim()) return res.status(400).json({ error: 'Missing filename' })
+  if (typeof content_base64 !== 'string' || !content_base64)
+    return res.status(400).json({ error: 'Missing file content' })
+
+  let buffer: Buffer
+  try {
+    buffer = Buffer.from(content_base64, 'base64')
+  } catch {
+    return res.status(400).json({ error: 'Invalid file content' })
+  }
+
+  if (!buffer.length) return res.status(400).json({ error: 'Empty file' })
+  if (buffer.length > MAX_BYTES) return res.status(400).json({ error: 'File too large (max 4 MB)' })
+
+  const safeFilename = sanitizeFilename(filename)
+  const uploadId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const storagePath = `ballot-design-uploads/${election_id}/${uploadId}-${safeFilename}`
+
+  await firebase
+    .storage()
+    .bucket()
+    .file(storagePath)
+    .save(buffer, {
+      metadata: { contentType: typeof mime_type === 'string' ? mime_type : 'application/octet-stream' },
+    })
+
+  const format = detectFormat(buffer, safeFilename)
+
+  await firebase
+    .firestore()
+    .collection('elections')
+    .doc(election_id)
+    .collection('ballot-design-uploads')
+    .doc(uploadId)
+    .set({
+      filename: safeFilename,
+      format: format ?? 'unknown',
+      mime_type: typeof mime_type === 'string' ? mime_type : null,
+      size: buffer.length,
+      storage_path: storagePath,
+      uploaded_at: new Date(),
+      uploaded_by: jwt.email,
+    })
+
+  await pushover(
+    'Ballot design upload',
+    `${jwt.election_title} (${election_id})\n${safeFilename} (${buffer.length} bytes)\nformat: ${format ?? 'unknown'}`,
+  )
+
+  return res.status(201).json({ format, success: true })
+}

--- a/src/admin/BallotDesign/BallotDesign.tsx
+++ b/src/admin/BallotDesign/BallotDesign.tsx
@@ -39,7 +39,7 @@ export const BallotDesign = () => {
     <>
       <TipToRunPracticeVote />
 
-      <h2 className="hidden mb-0 sm:block">
+      <h2 className="hidden sm:block">
         Ballot Design
         <span className="ml-3">
           <PreviewButton election_id={election_id} />
@@ -66,7 +66,7 @@ export const BallotDesign = () => {
       />
       {upload_message && (
         <p
-          className={`mt-1 mb-0 text-xs max-w-md text-right ${
+          className={`clear-both pt-1 text-xs max-w-xl ${
             upload_message.status === 'error' ? 'text-red-600' : 'text-gray-600'
           }`}
         >

--- a/src/admin/BallotDesign/BallotDesign.tsx
+++ b/src/admin/BallotDesign/BallotDesign.tsx
@@ -66,7 +66,7 @@ export const BallotDesign = () => {
       />
       {upload_message && (
         <p
-          className={`mt-1 text-xs max-w-md text-right ${
+          className={`mt-1 mb-0 text-xs max-w-md text-right ${
             upload_message.status === 'error' ? 'text-red-600' : 'text-gray-600'
           }`}
         >

--- a/src/admin/BallotDesign/BallotDesign.tsx
+++ b/src/admin/BallotDesign/BallotDesign.tsx
@@ -11,6 +11,7 @@ import { FinalizeBallotDesignButton } from './FinalizeBallotDesignButton'
 import { JsonEditor } from './JsonEditor'
 import { ModeControls } from './ModeControls'
 import { TipToRunPracticeVote } from './TipToRunPracticeVote'
+import { UploadBallotDesignButton } from './UploadBallotDesignButton'
 import { Wizard } from './Wizard'
 
 export const BallotDesign = () => {
@@ -42,6 +43,9 @@ export const BallotDesign = () => {
         Ballot Design
         <span className="ml-3">
           <PreviewButton election_id={election_id} />
+          {!ballot_design_finalized && (
+            <UploadBallotDesignButton election_id={election_id} setDesign={setDesignIfNotFinalized} />
+          )}
         </span>
       </h2>
 
@@ -49,6 +53,9 @@ export const BallotDesign = () => {
 
       <div className="mt-3 sm:hidden">
         <PreviewButton election_id={election_id} />
+        {!ballot_design_finalized && (
+          <UploadBallotDesignButton election_id={election_id} setDesign={setDesignIfNotFinalized} />
+        )}
       </div>
 
       <Errors {...{ error }} />

--- a/src/admin/BallotDesign/BallotDesign.tsx
+++ b/src/admin/BallotDesign/BallotDesign.tsx
@@ -21,7 +21,6 @@ export const BallotDesign = () => {
   const setDesignIfNotFinalized = !ballot_design_finalized ? setDesign : () => alert('Ballot design already finalized')
 
   const [saving_errors, set_saving_errors] = useState<null | string>(null)
-  const [upload_message, set_upload_message] = useState<null | { status: 'error' | 'success'; text: string }>(null)
 
   const error = check_for_fatal_ballot_errors(design) || saving_errors
 
@@ -57,22 +56,12 @@ export const BallotDesign = () => {
       <ModeControls
         {...{
           election_id,
-          onUploadMessage: (text, status) => set_upload_message(text ? { status, text } : null),
           selected,
           setDesign: setDesignIfNotFinalized,
           setSelected,
           showUpload: !ballot_design_finalized,
         }}
       />
-      {upload_message && (
-        <p
-          className={`clear-both pt-1 text-xs max-w-xl ${
-            upload_message.status === 'error' ? 'text-red-600' : 'text-gray-600'
-          }`}
-        >
-          {upload_message.text}
-        </p>
-      )}
       <div className="relative flex w-full top-[3px]">
         {selected !== 1 && <Wizard {...{ design, setDesign: setDesignIfNotFinalized }} />}
         {selected === 2 && <div className="w-5" /> /* spacer */}

--- a/src/admin/BallotDesign/BallotDesign.tsx
+++ b/src/admin/BallotDesign/BallotDesign.tsx
@@ -11,7 +11,6 @@ import { FinalizeBallotDesignButton } from './FinalizeBallotDesignButton'
 import { JsonEditor } from './JsonEditor'
 import { ModeControls } from './ModeControls'
 import { TipToRunPracticeVote } from './TipToRunPracticeVote'
-import { UploadBallotDesignButton } from './UploadBallotDesignButton'
 import { Wizard } from './Wizard'
 
 export const BallotDesign = () => {
@@ -22,6 +21,7 @@ export const BallotDesign = () => {
   const setDesignIfNotFinalized = !ballot_design_finalized ? setDesign : () => alert('Ballot design already finalized')
 
   const [saving_errors, set_saving_errors] = useState<null | string>(null)
+  const [upload_message, set_upload_message] = useState<null | { status: 'error' | 'success'; text: string }>(null)
 
   const error = check_for_fatal_ballot_errors(design) || saving_errors
 
@@ -39,13 +39,10 @@ export const BallotDesign = () => {
     <>
       <TipToRunPracticeVote />
 
-      <h2 className="hidden sm:block">
+      <h2 className="hidden mb-0 sm:block">
         Ballot Design
         <span className="ml-3">
           <PreviewButton election_id={election_id} />
-          {!ballot_design_finalized && (
-            <UploadBallotDesignButton election_id={election_id} setDesign={setDesignIfNotFinalized} />
-          )}
         </span>
       </h2>
 
@@ -53,14 +50,29 @@ export const BallotDesign = () => {
 
       <div className="mt-3 sm:hidden">
         <PreviewButton election_id={election_id} />
-        {!ballot_design_finalized && (
-          <UploadBallotDesignButton election_id={election_id} setDesign={setDesignIfNotFinalized} />
-        )}
       </div>
 
       <Errors {...{ error }} />
 
-      <ModeControls {...{ selected, setSelected }} />
+      <ModeControls
+        {...{
+          election_id,
+          onUploadMessage: (text, status) => set_upload_message(text ? { status, text } : null),
+          selected,
+          setDesign: setDesignIfNotFinalized,
+          setSelected,
+          showUpload: !ballot_design_finalized,
+        }}
+      />
+      {upload_message && (
+        <p
+          className={`mt-1 text-xs max-w-md text-right ${
+            upload_message.status === 'error' ? 'text-red-600' : 'text-gray-600'
+          }`}
+        >
+          {upload_message.text}
+        </p>
+      )}
       <div className="relative flex w-full top-[3px]">
         {selected !== 1 && <Wizard {...{ design, setDesign: setDesignIfNotFinalized }} />}
         {selected === 2 && <div className="w-5" /> /* spacer */}

--- a/src/admin/BallotDesign/ModeControls.tsx
+++ b/src/admin/BallotDesign/ModeControls.tsx
@@ -1,4 +1,20 @@
-export const ModeControls = ({ selected, setSelected }: { selected: number; setSelected: (s: number) => void }) => {
+import { UploadBallotDesignButton } from './UploadBallotDesignButton'
+
+export const ModeControls = ({
+  election_id,
+  onUploadMessage,
+  selected,
+  setDesign,
+  setSelected,
+  showUpload,
+}: {
+  election_id?: string
+  onUploadMessage?: (message: string, status: 'error' | 'success') => void
+  selected: number
+  setDesign?: (design: string) => void
+  setSelected: (s: number) => void
+  showUpload?: boolean
+}) => {
   return (
     <div className="float-right">
       {['Wizard', 'JSON', 'Split'].map((label, index) => (
@@ -12,6 +28,9 @@ export const ModeControls = ({ selected, setSelected }: { selected: number; setS
           {label}
         </span>
       ))}
+      {showUpload && setDesign && (
+        <UploadBallotDesignButton election_id={election_id} onMessage={onUploadMessage} setDesign={setDesign} />
+      )}
     </div>
   )
 }

--- a/src/admin/BallotDesign/ModeControls.tsx
+++ b/src/admin/BallotDesign/ModeControls.tsx
@@ -2,14 +2,12 @@ import { UploadBallotDesignButton } from './UploadBallotDesignButton'
 
 export const ModeControls = ({
   election_id,
-  onUploadMessage,
   selected,
   setDesign,
   setSelected,
   showUpload,
 }: {
   election_id?: string
-  onUploadMessage?: (message: string, status: 'error' | 'success') => void
   selected: number
   setDesign?: (design: string) => void
   setSelected: (s: number) => void
@@ -28,9 +26,7 @@ export const ModeControls = ({
           {label}
         </span>
       ))}
-      {showUpload && setDesign && (
-        <UploadBallotDesignButton election_id={election_id} onMessage={onUploadMessage} setDesign={setDesign} />
-      )}
+      {showUpload && setDesign && <UploadBallotDesignButton election_id={election_id} setDesign={setDesign} />}
     </div>
   )
 }

--- a/src/admin/BallotDesign/UploadBallotDesignButton.tsx
+++ b/src/admin/BallotDesign/UploadBallotDesignButton.tsx
@@ -5,6 +5,8 @@ import { Spinner } from '../Spinner'
 const tabClassName =
   'select-none cursor-pointer border border-solid border-gray-400/70 border-l-0 hover:bg-gray-50 active:bg-gray-200 px-[15px] py-[5px]'
 
+const uploadConfirmMessage = 'Your format may not auto-import yet — but uploading helps add support for it sooner.'
+
 export const UploadBallotDesignButton = ({
   election_id,
   setDesign,
@@ -58,7 +60,23 @@ export const UploadBallotDesignButton = ({
   }
 
   return (
-    <label className={`${tabClassName} hidden sm:inline ${uploading ? 'opacity-50 pointer-events-none' : ''}`}>
+    <>
+      <span
+        className={`${tabClassName} hidden sm:inline ${uploading ? 'opacity-50 pointer-events-none' : ''}`}
+        onClick={() => {
+          if (uploading) return
+          if (!confirm(uploadConfirmMessage)) return
+          inputRef.current?.click()
+        }}
+      >
+        {uploading ? (
+          <>
+            <Spinner /> Uploading...
+          </>
+        ) : (
+          'Upload'
+        )}
+      </span>
       <input
         className="hidden"
         onChange={(e) => {
@@ -68,13 +86,6 @@ export const UploadBallotDesignButton = ({
         ref={inputRef}
         type="file"
       />
-      {uploading ? (
-        <>
-          <Spinner /> Uploading...
-        </>
-      ) : (
-        'Upload'
-      )}
-    </label>
+    </>
   )
 }

--- a/src/admin/BallotDesign/UploadBallotDesignButton.tsx
+++ b/src/admin/BallotDesign/UploadBallotDesignButton.tsx
@@ -2,16 +2,23 @@ import { useRef, useState } from 'react'
 
 import { Spinner } from '../Spinner'
 
+const tabClassName =
+  'select-none cursor-pointer border border-solid border-gray-400/70 border-l-0 hover:bg-gray-50 active:bg-gray-200 px-[15px] py-[5px]'
+
 export const UploadBallotDesignButton = ({
   election_id,
+  onMessage,
   setDesign,
 }: {
   election_id?: string
+  onMessage?: (message: string, status: 'error' | 'success') => void
   setDesign: (design: string) => void
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [status, setStatus] = useState<'error' | 'idle' | 'success' | 'uploading'>('idle')
-  const [message, setMessage] = useState('')
+
+  const setMessage = (message: string, messageStatus: 'error' | 'success' = 'success') =>
+    onMessage?.(message, messageStatus)
 
   const handleFile = async (file: File) => {
     if (!election_id) return
@@ -41,7 +48,7 @@ export const UploadBallotDesignButton = ({
     const json = await response.json().catch(() => ({}))
     if (!response.ok) {
       setStatus('error')
-      setMessage(json.error || 'Upload failed')
+      setMessage(json.error || 'Upload failed', 'error')
       return
     }
 
@@ -60,21 +67,7 @@ export const UploadBallotDesignButton = ({
   }
 
   return (
-    <span className="inline-block ml-2">
-      <button
-        className="inline-block text-[12px] font-semibold hover:bg-gray-100 px-3 py-1 border border-blue-900 border-solid rounded-lg relative bottom-0.5 text-blue-900 bg-transparent cursor-pointer disabled:opacity-50"
-        disabled={status === 'uploading'}
-        onClick={() => inputRef.current?.click()}
-        type="button"
-      >
-        {status === 'uploading' ? (
-          <>
-            <Spinner /> Uploading...
-          </>
-        ) : (
-          'Upload ballot design'
-        )}
-      </button>
+    <label className={`${tabClassName} ${status === 'uploading' ? 'opacity-50 pointer-events-none' : ''}`}>
       <input
         className="hidden"
         onChange={(e) => {
@@ -84,9 +77,13 @@ export const UploadBallotDesignButton = ({
         ref={inputRef}
         type="file"
       />
-      {message && (
-        <p className={`mt-2 text-xs max-w-md ${status === 'error' ? 'text-red-600' : 'text-gray-600'}`}>{message}</p>
+      {status === 'uploading' ? (
+        <>
+          <Spinner /> Uploading...
+        </>
+      ) : (
+        'Upload'
       )}
-    </span>
+    </label>
   )
 }

--- a/src/admin/BallotDesign/UploadBallotDesignButton.tsx
+++ b/src/admin/BallotDesign/UploadBallotDesignButton.tsx
@@ -7,24 +7,18 @@ const tabClassName =
 
 export const UploadBallotDesignButton = ({
   election_id,
-  onMessage,
   setDesign,
 }: {
   election_id?: string
-  onMessage?: (message: string, status: 'error' | 'success') => void
   setDesign: (design: string) => void
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
-  const [status, setStatus] = useState<'error' | 'idle' | 'success' | 'uploading'>('idle')
-
-  const setMessage = (message: string, messageStatus: 'error' | 'success' = 'success') =>
-    onMessage?.(message, messageStatus)
+  const [uploading, setUploading] = useState(false)
 
   const handleFile = async (file: File) => {
     if (!election_id) return
 
-    setStatus('uploading')
-    setMessage('')
+    setUploading(true)
 
     const content_base64 = await new Promise<string>((resolve, reject) => {
       const reader = new FileReader()
@@ -46,28 +40,25 @@ export const UploadBallotDesignButton = ({
     })
 
     const json = await response.json().catch(() => ({}))
-    if (!response.ok) {
-      setStatus('error')
-      setMessage(json.error || 'Upload failed', 'error')
-      return
-    }
+    setUploading(false)
+    if (inputRef.current) inputRef.current.value = ''
+
+    if (!response.ok) return alert(json.error || 'Upload failed')
 
     if (json.format === 'siv_json') {
       const text = await file.text()
       if (confirm('Load this ballot design into the editor?')) {
         setDesign(JSON.stringify(JSON.parse(text), null, 2))
-        setMessage('Loaded into editor.')
-      } else setMessage('Uploaded.')
-    } else {
-      setMessage("Uploaded. We can't auto-parse this file format yet, but we're working to add support.")
+        return alert('Loaded into editor.')
+      }
+      return alert('Uploaded.')
     }
 
-    setStatus('success')
-    if (inputRef.current) inputRef.current.value = ''
+    alert("Uploaded. We can't auto-parse this file format yet, but we're working to add support.")
   }
 
   return (
-    <label className={`${tabClassName} ${status === 'uploading' ? 'opacity-50 pointer-events-none' : ''}`}>
+    <label className={`${tabClassName} ${uploading ? 'opacity-50 pointer-events-none' : ''}`}>
       <input
         className="hidden"
         onChange={(e) => {
@@ -77,7 +68,7 @@ export const UploadBallotDesignButton = ({
         ref={inputRef}
         type="file"
       />
-      {status === 'uploading' ? (
+      {uploading ? (
         <>
           <Spinner /> Uploading...
         </>

--- a/src/admin/BallotDesign/UploadBallotDesignButton.tsx
+++ b/src/admin/BallotDesign/UploadBallotDesignButton.tsx
@@ -1,0 +1,92 @@
+import { useRef, useState } from 'react'
+
+import { Spinner } from '../Spinner'
+
+export const UploadBallotDesignButton = ({
+  election_id,
+  setDesign,
+}: {
+  election_id?: string
+  setDesign: (design: string) => void
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [status, setStatus] = useState<'error' | 'idle' | 'success' | 'uploading'>('idle')
+  const [message, setMessage] = useState('')
+
+  const handleFile = async (file: File) => {
+    if (!election_id) return
+
+    setStatus('uploading')
+    setMessage('')
+
+    const content_base64 = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const result = reader.result
+        if (typeof result !== 'string') return reject(new Error('Failed to read file'))
+        const comma = result.indexOf(',')
+        if (comma === -1) return reject(new Error('Failed to read file'))
+        resolve(result.slice(comma + 1))
+      }
+      reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'))
+      reader.readAsDataURL(file)
+    })
+
+    const response = await fetch(`/api/election/${election_id}/admin/upload-ballot-design`, {
+      body: JSON.stringify({ content_base64, filename: file.name, mime_type: file.type || null }),
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      method: 'POST',
+    })
+
+    const json = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      setStatus('error')
+      setMessage(json.error || 'Upload failed')
+      return
+    }
+
+    if (json.format === 'siv_json') {
+      const text = await file.text()
+      if (confirm('Load this ballot design into the editor?')) {
+        setDesign(JSON.stringify(JSON.parse(text), null, 2))
+        setMessage('Loaded into editor.')
+      } else setMessage('Uploaded.')
+    } else {
+      setMessage("Uploaded. We can't auto-parse this file format yet, but we're working to add support.")
+    }
+
+    setStatus('success')
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  return (
+    <span className="inline-block ml-2">
+      <button
+        className="inline-block text-[12px] font-semibold hover:bg-gray-100 px-3 py-1 border border-blue-900 border-solid rounded-lg relative bottom-0.5 text-blue-900 bg-transparent cursor-pointer disabled:opacity-50"
+        disabled={status === 'uploading'}
+        onClick={() => inputRef.current?.click()}
+        type="button"
+      >
+        {status === 'uploading' ? (
+          <>
+            <Spinner /> Uploading...
+          </>
+        ) : (
+          'Upload ballot design'
+        )}
+      </button>
+      <input
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) handleFile(file)
+        }}
+        ref={inputRef}
+        type="file"
+      />
+      {message && (
+        <p className={`mt-2 text-xs max-w-md ${status === 'error' ? 'text-red-600' : 'text-gray-600'}`}>{message}</p>
+      )}
+    </span>
+  )
+}

--- a/src/admin/BallotDesign/UploadBallotDesignButton.tsx
+++ b/src/admin/BallotDesign/UploadBallotDesignButton.tsx
@@ -58,7 +58,7 @@ export const UploadBallotDesignButton = ({
   }
 
   return (
-    <label className={`${tabClassName} ${uploading ? 'opacity-50 pointer-events-none' : ''}`}>
+    <label className={`${tabClassName} hidden sm:inline ${uploading ? 'opacity-50 pointer-events-none' : ''}`}>
       <input
         className="hidden"
         onChange={(e) => {


### PR DESCRIPTION
# Upload Ballot Design Button

## Goal

Give election admins a way to upload existing ballot design files (PDF, CSV, vendor JSON, etc.) from the ballot designer. **No custom import parsers yet** — primary purpose is collection + admin signal. If the file is already valid SIV JSON, offer to load it into the editor.

<img width="842" height="254" alt="image" src="https://github.com/user-attachments/assets/d8d3c62e-6d81-4e85-9f76-2952ddfc92f3" />

Clicking upload button first shows a warning:

<img width="539" height="160" alt="image" src="https://github.com/user-attachments/assets/de1b5cf1-feef-476c-83d7-1c0921c13175" />

Then if they accept they get a standard file picker:

<img width="952" height="512" alt="image" src="https://github.com/user-attachments/assets/6bc8c2fb-dc34-4b84-8538-4bc033a2e6b6" />



- Upload is only available **before** ballot design is finalized (same gate as editing).
- Upload button hidden on mobile.

## Architecture

```mermaid
sequenceDiagram
    participant Admin
    participant BallotDesignUI
    participant API as upload-ballot-design API
    participant Storage as Firebase Storage
    participant FS as Firestore
    participant Push as Pushover

    Admin->>BallotDesignUI: Click Upload, pick file
    BallotDesignUI->>BallotDesignUI: FileReader to base64
    BallotDesignUI->>API: POST filename, mime, contentBase64
    API->>API: checkJwtOwnsElection, size check
    API->>Storage: Save bytes
    API->>FS: Write metadata doc
    API->>Push: Notify admin
    API-->>BallotDesignUI: success + format
    alt Supported format e.g. siv_json
        BallotDesignUI->>Admin: Confirm load into editor?
        Admin->>BallotDesignUI: Yes
        BallotDesignUI->>BallotDesignUI: setDesign(parsed JSON)
    end
```

## UI — [`src/admin/BallotDesign/BallotDesign.tsx`](src/admin/BallotDesign/BallotDesign.tsx)

Add an `UploadBallotDesignButton` next to the existing Preview button in the header (desktop + mobile rows). Only render when `!ballot_design_finalized`.

New component [`src/admin/BallotDesign/UploadBallotDesignButton.tsx`](src/admin/BallotDesign/UploadBallotDesignButton.tsx):

- Styled like `PreviewButton` (small bordered pill)
- Hidden `<input type="file">` triggered on click — **no `accept` attribute**; any file type the OS offers is fine (we're collecting formats, not guessing which ones matter yet)
- Read file client-side with `FileReader.readAsDataURL`, strip the `data:...;base64,` prefix
- POST via a small helper (not the shared `api()` helper — it always JSON-stringifies; fine to inline `fetch` here or add an optional base64 body field to the existing helper)
- States: idle / uploading / success message / error message
- On success (branch on API `format` field — `'siv_json'` today, extensible for future parsers):
  - **Unsupported format** (`format` absent or `'unknown'`): show *"Uploaded. We can't auto-parse this file format yet, but we're working to add support."*
  - **Supported format** (e.g. `format: 'siv_json'`): `confirm("Load this ballot design into the editor?")` → on Yes, `setDesign(JSON.stringify(parsed, null, 2))` and show *"Loaded into editor."*; on No, brief *"Uploaded."* (file still stored for our records)

Pass `setDesignIfNotFinalized` from `BallotDesign` into the upload button.

## API — [`pages/api/election/[election_id]/admin/upload-ballot-design.ts`](pages/api/election/[election_id]/admin/upload-ballot-design.ts)

Follow existing admin route patterns from [`save-ballot-design.ts`](pages/api/election/[election_id]/admin/save-ballot-design.ts):

- `checkJwtOwnsElection(req, res, election_id)`
- Reject if `jwt.ballot_design_finalized`
- Body: `{ filename, mime_type, content_base64 }`
- Route config: `export const config = { api: { bodyParser: { sizeLimit: '5mb' } } }` (first use of raised limit in this codebase; needed for PDFs)

Server logic:

1. Validate filename (non-empty string, strip path segments)
2. Decode base64 → `Buffer`, enforce max **4 MB** decoded size
3. **First Firebase Storage use** in this project — save to:
   `ballot-design-uploads/{election_id}/{timestamp}-{sanitized-filename}`
   via `firebase.storage().bucket()` (default bucket from existing `FIREBASE_PROJECT_ID` creds)
4. Write Firestore metadata to subcollection `elections/{election_id}/ballot-design-uploads/{uploadId}`:
   - `filename`, `mime_type`, `size`, `storage_path`, `uploaded_at`, `uploaded_by` (admin email)
5. **Format detection** (no other parsers yet): if content looks like JSON, try `JSON.parse` + reuse `check_for_fatal_ballot_errors` from [`check_for_ballot_errors.ts`](src/admin/BallotDesign/check_for_ballot_errors.ts). Set `format: 'siv_json'` only if no fatal errors; otherwise omit / `'unknown'`.
6. `pushover('Ballot design upload', ...)` with election title, filename, size, format

Response: `{ success: true, format?: 'siv_json' }` — omit `format` (or `'unknown'`) when we can't auto-parse; add new values here as parsers land

## What we're explicitly not building (yet)

- No parsers for PDF/CSV/vendor formats
- No admin UI to browse past uploads (data lives in Firestore + Storage for manual review)
- No upload after finalize
- No Firebase Storage security rules changes needed (admin SDK bypasses client rules)

## Files to touch

| File                                                                                 | Change             |
| ------------------------------------------------------------------------------------ | ------------------ |
| [`src/admin/BallotDesign/BallotDesign.tsx`](src/admin/BallotDesign/BallotDesign.tsx) | Wire upload button |
| `src/admin/BallotDesign/UploadBallotDesignButton.tsx`                                | New UI component   |
| `pages/api/election/[election_id]/admin/upload-ballot-design.ts`                     | New API route      |

## Manual test plan

1. Open ballot designer (unfinalized election) → see Upload button beside Preview
2. Upload a PDF → success message, Pushover received, doc in `ballot-design-uploads` subcollection + file in Storage
3. Upload arbitrary unsupported file (e.g. PDF) → "can't auto-parse" message only
4. Upload valid SIV JSON → load prompt → "Loaded into editor." (or "Uploaded." if declined)
5. Finalize ballot design → Upload button hidden
6. File over 4 MB → clear error, no partial write


## Todos:

- [x] **api-upload**: Create upload-ballot-design API route (JWT, Storage write, Firestore metadata, Pushover, SIV JSON detection)
- [x] **ui-button**: Add UploadBallotDesignButton component with file picker, upload flow, and optional SIV JSON load prompt
- [x] **wire-ballot-design**: Wire button into BallotDesign header (before finalize only)
- [x] Make it look nice
- [x] Configure storage to be able to receive uploads
