### PR TITLE
Strengthened Verif Numbers — v1

### DIFF
--- a/pages/api/_with-api-error-logs.ts
+++ b/pages/api/_with-api-error-logs.ts
@@ -1,0 +1,32 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
+
+/** Log 4xx/5xx response bodies to stdout (visible in Vercel runtime logs). */
+export function withApiErrorLogs(handler: NextApiHandler): NextApiHandler {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const path = req.url
+    const origJson = res.json.bind(res)
+    const origSend = res.send.bind(res)
+    const origEnd = res.end.bind(res)
+
+    const logIfError = (body?: unknown) => {
+      if (res.statusCode >= 400) console.error(path, res.statusCode, body ?? '')
+    }
+
+    res.json = (body) => {
+      logIfError(body)
+      return origJson(body)
+    }
+    res.send = (body) => {
+      logIfError(body)
+      return origSend(body)
+    }
+    // Some routes only set status + end()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res.end = ((...args: any[]) => {
+      if (!res.writableEnded) logIfError(args[0])
+      return origEnd(...args)
+    }) as typeof res.end
+
+    return handler(req, res)
+  }
+}

--- a/pages/api/election/[election_id]/admin/load-admin.ts
+++ b/pages/api/election/[election_id]/admin/load-admin.ts
@@ -14,7 +14,10 @@ export type AdminData = {
   election_manager?: string
   election_title?: string
   esignature_requested?: boolean
+  last_decrypted_at?: string
   notified_unlocked?: number
+  num_strengthened_since_unlock?: number
+  num_strengthened_votes?: number
   pending_votes?: PendingVote[]
   public_whos_voted_snapshot?: Array<{ display_name?: string; has_voted: boolean }>
   stop_accepting_votes?: boolean
@@ -97,6 +100,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     election_manager,
     election_title,
     esignature_requested,
+    last_decrypted_at,
     notified_unlocked,
     public_whos_voted_snapshot,
     stop_accepting_votes,
@@ -112,6 +116,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     election_manager?: string
     election_title?: string
     esignature_requested?: boolean
+    last_decrypted_at?: { _seconds: number }
     notified_unlocked?: number
     public_whos_voted_snapshot?: Array<{ display_name?: string; has_voted: boolean }>
     stop_accepting_votes?: boolean
@@ -150,10 +155,22 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   }, [])
 
   // Gather who's voted already
-  const votesByAuth: Record<string, [boolean, string?]> = (await loadVotes).docs.reduce((acc, doc) => {
+  const voteDocs = (await loadVotes).docs
+  const votesByAuth: Record<string, [boolean, string?]> = voteDocs.reduce((acc, doc) => {
     const data = doc.data()
     return { ...acc, [data.auth]: [true, data.esignature] }
   }, {})
+
+  // Strengthened counts from vote docs (accepted + pending)
+  const lastUnlockMs = last_decrypted_at ? last_decrypted_at._seconds * 1000 : 0
+  const strengthenedAts = [
+    ...voteDocs.map((d) => d.data().strengthened_at),
+    ...(await loadPendingVotes).docs.map((d) => d.data().strengthened_at),
+  ]
+    .map((t) => t?.toMillis?.() ?? (t instanceof Date ? t.getTime() : 0))
+    .filter((ms) => ms > 0)
+  const num_strengthened_votes = strengthenedAts.length
+  const num_strengthened_since_unlock = lastUnlockMs ? strengthenedAts.filter((ms) => ms > lastUnlockMs).length : 0
 
   // Gather whose votes were invalidated
   const invalidatedVotesByAuth: Record<string, boolean> = {}
@@ -246,7 +263,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     election_manager,
     election_title,
     esignature_requested,
+    last_decrypted_at: last_decrypted_at ? new Date(last_decrypted_at._seconds * 1000).toISOString() : undefined,
     notified_unlocked,
+    num_strengthened_since_unlock,
+    num_strengthened_votes,
     pending_votes,
     public_whos_voted_snapshot,
     stop_accepting_votes,

--- a/pages/api/election/[election_id]/cache-accepted.test.ts
+++ b/pages/api/election/[election_id]/cache-accepted.test.ts
@@ -37,7 +37,12 @@ const helpers = {
   submitTestVote: async (electionId: string, auth: string, encryptedVote: Record<string, unknown> = {}) => {
     // Helper to submit a vote via the API
     return fetch(`${API_BASE}/submit-vote`, {
-      body: JSON.stringify({ auth, election_id: electionId, encrypted_vote: JSON.stringify(encryptedVote) }),
+      body: JSON.stringify({
+        auth,
+        election_id: electionId,
+        encrypted_vote: JSON.stringify(encryptedVote),
+        replacement_pubkey: 'a'.repeat(64),
+      }),
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
     })

--- a/pages/api/election/[election_id]/cache-accepted.test.ts
+++ b/pages/api/election/[election_id]/cache-accepted.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test'
+import { encodeReplacementPayload, generateReplacementKeypair, signReplacement } from 'src/crypto/replacement-key'
+import { CipherStrings } from 'src/crypto/stringify-shuffle'
 
 const API_BASE = 'http://localhost:3000/api'
 
@@ -34,14 +36,39 @@ const helpers = {
     const body = await response.json()
     return { body, status: response.status }
   },
-  submitTestVote: async (electionId: string, auth: string, encryptedVote: Record<string, unknown> = {}) => {
+  strengthenTestVote: async ({
+    auth,
+    electionId,
+    encryptedVote,
+    privkey,
+  }: {
+    auth: string
+    electionId: string
+    encryptedVote: Record<string, CipherStrings>
+    privkey: string
+  }) => {
+    const message = encodeReplacementPayload({ auth, election_id: electionId, encrypted_vote: encryptedVote })
+    const signature = await signReplacement(privkey, message)
+    const response = await fetch(`${API_BASE}/strengthened-vote`, {
+      body: JSON.stringify({ auth, election_id: electionId, encrypted_vote: encryptedVote, signature }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    })
+    return { body: await response.json(), status: response.status }
+  },
+  submitTestVote: async (
+    electionId: string,
+    auth: string,
+    encryptedVote: Record<string, unknown> = {},
+    replacement_pubkey = 'a'.repeat(64),
+  ) => {
     // Helper to submit a vote via the API
     return fetch(`${API_BASE}/submit-vote`, {
       body: JSON.stringify({
         auth,
         election_id: electionId,
         encrypted_vote: JSON.stringify(encryptedVote),
-        replacement_pubkey: 'a'.repeat(64),
+        replacement_pubkey,
       }),
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
@@ -165,6 +192,48 @@ test('Voting During Packing - vote not lost', async () => {
     // Verify vote counts are correct
     const stats = readBody?._stats
     expect(stats).toBeDefined()
+  } finally {
+    await helpers.cleanupTestElection(electionId)
+  }
+}, 15_000)
+
+// Test 3: Strengthened vote updates packed cache (invalidateCachedVote)
+test('Strengthened vote - packed ciphertext is replaced in cache-accepted', async () => {
+  const electionId = `test-strengthen-cache-${Date.now()}`
+  const auth = 'c1d2e3f4a5'
+  const original = { mayor: { encrypted: 'old_enc', lock: 'old_lock' } }
+  const strengthened = { mayor: { encrypted: 'new_enc', lock: 'new_lock' } }
+
+  try {
+    expect((await helpers.createTestElection(electionId)).status).toBe(201)
+    expect((await helpers.createTestVoters(electionId, [{ auth_token: auth }])).status).toBe(201)
+
+    const { replacement_privkey, replacement_pubkey } = await generateReplacementKeypair()
+    expect((await helpers.submitTestVote(electionId, auth, original, replacement_pubkey)).status).toBe(200)
+
+    // Pack so the vote is no longer only in the live tail
+    const packed = await helpers.callCacheAccepted(electionId)
+    expect(packed.status).toBe(200)
+    const packedBody = packed.body as {
+      results: Array<{ auth: string; mayor?: CipherStrings }>
+    }
+    const before = packedBody.results.find((r) => r.auth === auth)
+    expect(before?.mayor).toEqual(original.mayor)
+
+    const strengthen = await helpers.strengthenTestVote({
+      auth,
+      electionId,
+      encryptedVote: strengthened,
+      privkey: replacement_privkey,
+    })
+    expect(strengthen.status).toBe(200)
+
+    const after = await helpers.callCacheAccepted(electionId)
+    expect(after.status).toBe(200)
+    const afterBody = after.body as { results: Array<{ auth: string; mayor?: CipherStrings }> }
+    const vote = afterBody.results.find((r) => r.auth === auth)
+    expect(vote?.mayor).toEqual(strengthened.mayor)
+    expect(afterBody.results).toHaveLength(1)
   } finally {
     await helpers.cleanupTestElection(electionId)
   }

--- a/pages/api/election/[election_id]/cache-accepted.ts
+++ b/pages/api/election/[election_id]/cache-accepted.ts
@@ -5,6 +5,7 @@ import { firestore } from 'firebase-admin'
 import { CipherStrings } from 'src/crypto/stringify-shuffle'
 
 import { firebase, pushover } from '../../_services'
+import { isPackedByCursor, type TimestampLike } from './is-packed-by-cursor'
 
 type EncryptedVote = Record<string, CipherStrings>
 type PendingVoteSummary = EncryptedVote & { auth: 'pending'; link_auth?: string }
@@ -16,6 +17,7 @@ type RootMeta = {
   observedVotes: number
   packedPending: number
   packedVotes: number
+  revision?: number
   updatedAt: firestore.Timestamp
 }
 type VoteSummary = EncryptedVote & { auth: string }
@@ -92,6 +94,7 @@ const makeEtag = ({
     root.lastPackedDocId ?? '',
     observedVotes,
     observedPending,
+    root.revision ?? 0,
   ].join('|')
 
   return createHash('sha1').update(seed).digest('hex').slice(0, 12)
@@ -122,6 +125,7 @@ const getOrInitRoot = async (rootRef: firestore.DocumentReference) => {
     observedVotes: 0,
     packedPending: 0,
     packedVotes: 0,
+    revision: 0,
     updatedAt: firestore.Timestamp.fromMillis(Date.now() - PACK_THROTTLE_MS), // so first request can pack immediately
   }
 
@@ -296,6 +300,127 @@ const maybePackNewVotes = async (args: {
   } finally {
     await releaseLease(db, leaseRef, lease.owner)
   }
+}
+
+/**
+ * After an in-place ciphertext replace (e.g. strengthen), keep /cache-accepted fresh:
+ * - If the vote is still in the packer's tail → no-op (live query already sees the update).
+ * - If packed → patch that page entry and bump root.revision (ETag).
+ * - If lease busy or page entry missing → full cache reset (correctness over cost).
+ */
+export async function invalidateCachedVote(
+  electionDoc: firestore.DocumentReference,
+  {
+    auth,
+    created_at,
+    encrypted_vote,
+    pending = false,
+    vote_doc_id,
+  }: {
+    auth: string
+    created_at?: TimestampLike
+    encrypted_vote: EncryptedVote
+    pending?: boolean
+    vote_doc_id: string
+  },
+): Promise<'patched' | 'reset' | 'skipped'> {
+  const rootRef = electionDoc.collection('votes-cached').doc('root')
+  const pagesCol = rootRef.collection('pages')
+  const leaseRef = electionDoc.collection('votes-cached').doc('lease')
+  const db = electionDoc.firestore
+
+  // No cache yet — nothing to invalidate
+  const rootSnap = await rootRef.get()
+  if (!rootSnap.exists) return 'skipped'
+  const root = rootSnap.data() as RootMeta
+
+  // Still in packer's tail — live query already sees the update
+  if (!isPackedByCursor(created_at, vote_doc_id, root.lastPackedCreatedAt, root.lastPackedDocId)) return 'skipped'
+
+  // Hold pack lease so we don't race a packer rewriting pages
+  const lease = await tryAcquireLease(db, leaseRef, LEASE_TTL_MS)
+  if (!lease.ok || !lease.owner) {
+    await resetVotesCache(electionDoc)
+    return 'reset'
+  }
+
+  let didReset = false
+  try {
+    // Find the packed entry and swap in the new ciphertext
+    const snap = await pagesCol.orderBy(firestore.FieldPath.documentId()).get()
+    let found = false
+
+    for (const page of snap.docs) {
+      const data = (page.data() as { pendingVotes?: PendingVoteSummary[]; votes?: VoteSummary[] }) || {}
+      const votes = data.votes ?? []
+      const pendingVotes = data.pendingVotes ?? []
+      let changed = false
+
+      // Search accepted_votes for match on auth
+      const nextVotes = votes.map((v) => {
+        if (pending || v.auth !== auth) return v
+        changed = true
+        found = true
+        return { auth: v.auth, ...encrypted_vote } as VoteSummary
+      })
+      // Search pending_votes for match on link_auth
+      const nextPending = pendingVotes.map((pv) => {
+        if (!pending || pv.link_auth !== auth) return pv
+        changed = true
+        found = true
+        return { auth: 'pending' as const, ...encrypted_vote, link_auth: pv.link_auth }
+      })
+
+      // No matches found, continue onto next page
+      if (!changed) continue
+
+      // Rewrite just this page
+      await page.ref.set({
+        bytesApprox: approxBytes({ pendingVotes: nextPending, votes: nextVotes }),
+        pendingVotes: nextPending,
+        votes: nextVotes,
+      })
+      break // Auth should appear once, so stop scanning
+    }
+
+    // Cursor said packed, but entry missing — fall back to full rebuild
+    if (!found) {
+      await resetVotesCache(electionDoc)
+      didReset = true
+      return 'reset'
+    }
+
+    // Bump revision so ETag / CDN clients don't keep the old body
+    await rootRef.set({ revision: (root.revision ?? 0) + 1 }, { merge: true })
+    return 'patched'
+  } finally {
+    if (!didReset) await releaseLease(db, leaseRef, lease.owner)
+  }
+}
+
+/** Wipe packed pages so the next /cache-accepted rebuilds from live votes. */
+async function resetVotesCache(electionDoc: firestore.DocumentReference) {
+  const rootRef = electionDoc.collection('votes-cached').doc('root')
+  const pages = await rootRef.collection('pages').listDocuments()
+  await Promise.all([
+    ...pages.map((page) => page.delete()),
+    rootRef.set({
+      currentPageNum: 1,
+      lastPackedCreatedAt: null,
+      lastPackedDocId: null,
+      observedPending: 0,
+      observedVotes: 0,
+      packedPending: 0,
+      packedVotes: 0,
+      revision: 0,
+      updatedAt: firestore.Timestamp.fromMillis(Date.now() - PACK_THROTTLE_MS),
+    } satisfies RootMeta),
+    electionDoc
+      .collection('votes-cached')
+      .doc('lease')
+      .delete()
+      .catch(() => undefined),
+  ])
 }
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
@@ -534,8 +659,14 @@ Packing strategy (best-effort):
 - Lease is a single doc with TTL; acquisition is transactional.
 
 ETag:
-- ETag is derived from (cursor + observed counters) so it matches the representation we serve.
+- ETag is derived from (cursor + observed counters + revision) so it matches the representation we serve.
 - Important: ETag must change if response body would change, even if root didn’t pack yet.
+- revision bumps when a packed vote is patched in place (see invalidateCachedVote).
+
+In-place ciphertext updates (strengthen / later selection replace):
+- Packing is append-only by cursor; updating a vote doc does not re-pack it.
+- invalidateCachedVote: skip if still in tail; else patch the page entry + bump revision;
+  full reset only if lease busy or the packed entry is missing.
 
 Important invariants:
 - Cursor ordering is (created_at ASC, docId ASC) for both votes collections.

--- a/pages/api/election/[election_id]/is-packed-by-cursor.test.ts
+++ b/pages/api/election/[election_id]/is-packed-by-cursor.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+
+import { isPackedByCursor } from './is-packed-by-cursor'
+
+const ts = (ms: number) => ({ toMillis: () => ms })
+
+describe('isPackedByCursor', () => {
+  test('nothing packed yet → not packed', () => {
+    expect(isPackedByCursor(ts(100), 'a', null, null)).toBe(false)
+    expect(isPackedByCursor(ts(100), 'a', ts(100), null)).toBe(false)
+  })
+
+  test('before / after / equal cursor', () => {
+    const cursorAt = ts(100)
+    const cursorId = 'm'
+
+    expect(isPackedByCursor(ts(50), 'z', cursorAt, cursorId)).toBe(true)
+    expect(isPackedByCursor(ts(150), 'a', cursorAt, cursorId)).toBe(false)
+    expect(isPackedByCursor(ts(100), 'a', cursorAt, cursorId)).toBe(true)
+    expect(isPackedByCursor(ts(100), 'm', cursorAt, cursorId)).toBe(true)
+    expect(isPackedByCursor(ts(100), 'z', cursorAt, cursorId)).toBe(false)
+  })
+})

--- a/pages/api/election/[election_id]/is-packed-by-cursor.ts
+++ b/pages/api/election/[election_id]/is-packed-by-cursor.ts
@@ -1,0 +1,22 @@
+export type TimestampLike = Date | null | undefined | { toMillis: () => number }
+
+const toMillis = (t: TimestampLike) => {
+  if (!t) return 0
+  if (t instanceof Date) return t.getTime()
+  return t.toMillis()
+}
+
+/** True if (created_at, docId) is at or before the pack cursor — already in a cached page. */
+export function isPackedByCursor(
+  created_at: TimestampLike,
+  docId: string,
+  lastPackedCreatedAt: null | undefined | { toMillis: () => number },
+  lastPackedDocId: null | string | undefined,
+): boolean {
+  if (!lastPackedCreatedAt || !lastPackedDocId) return false
+  const t = toMillis(created_at)
+  const packedT = lastPackedCreatedAt.toMillis()
+  if (t < packedT) return true
+  if (t > packedT) return false
+  return docId <= lastPackedDocId
+}

--- a/pages/api/strengthened-vote.ts
+++ b/pages/api/strengthened-vote.ts
@@ -1,0 +1,74 @@
+import { firestore } from 'firebase-admin'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { encodeReplacementPayload, is64HexChars, is128HexChars, verifyReplacement } from 'src/crypto/replacement-key'
+import { CipherStrings } from 'src/crypto/stringify-shuffle'
+
+import { firebase } from './_services'
+import { withApiErrorLogs } from './_with-api-error-logs'
+import { invalidateCachedVote } from './election/[election_id]/cache-accepted'
+
+export default withApiErrorLogs(async (req: NextApiRequest, res: NextApiResponse) => {
+  // Validate body
+  const { auth, election_id, encrypted_vote, signature } = req.body || {}
+  if (!election_id || typeof election_id !== 'string') return res.status(400).json({ error: 'Missing Election ID' })
+  if (!auth || typeof auth !== 'string') return res.status(400).json({ error: 'Missing auth' })
+  if (!encrypted_vote || typeof encrypted_vote !== 'object')
+    return res.status(400).json({ error: 'Missing encrypted_vote' })
+  if (!is128HexChars(signature)) return res.status(400).json({ error: 'Missing or malformed signature' })
+
+  // Load election
+  const electionDoc = firebase.firestore().collection('elections').doc(election_id)
+  const election = await electionDoc.get()
+  if (!election.exists) return res.status(400).json({ error: 'Unknown Election ID' })
+  if (election.data()?.stop_accepting_votes)
+    return res.status(400).json({ error: 'The election administrator has stopped accepting new votes.' })
+
+  // Find existing vote (accepted first, then pending/link)
+  let voteSnap = await electionDoc.collection('votes').where('auth', '==', auth).limit(1).get()
+  if (voteSnap.empty)
+    voteSnap = await electionDoc.collection('votes-pending').where('link_auth', '==', auth).limit(1).get()
+  if (voteSnap.empty) return res.status(404).json({ error: 'No vote found for this auth' })
+
+  // Require device replacement pubkey from original submit
+  const voteDoc = voteSnap.docs[0]
+  const vote = voteDoc.data()
+  const { replacement_pubkey } = vote
+  if (!is64HexChars(replacement_pubkey))
+    return res.status(400).json({ error: 'Vote has no replacement_pubkey; cannot authorize replace' })
+
+  // Verify signature over the new encrypted_vote
+  const message = encodeReplacementPayload({
+    auth,
+    election_id,
+    encrypted_vote: encrypted_vote as Record<string, CipherStrings>,
+  })
+  if (!(await verifyReplacement(replacement_pubkey, signature, message)))
+    return res.status(401).json({ error: 'Invalid replacement signature' })
+
+  // Archive prior ciphertext, swap in the new one, keep votes cache fresh
+  const replaced_at = new Date()
+  const pending = voteDoc.ref.parent.id === 'votes-pending'
+  await Promise.all([
+    voteDoc.ref.update({
+      encrypted_vote,
+      previous_submissions: firestore.FieldValue.arrayUnion({
+        encrypted_vote: vote.encrypted_vote,
+        replaced_at,
+        ...(vote.created_at && { created_at: vote.created_at }),
+        ...(vote.strengthened_at && { strengthened_at: vote.strengthened_at }),
+      }),
+      strengthened_at: replaced_at,
+    }),
+
+    // Ensure /cache-accepted serves the latest ciphertext
+    invalidateCachedVote(electionDoc, {
+      auth,
+      created_at: vote.created_at,
+      encrypted_vote,
+      pending,
+      vote_doc_id: voteDoc.id,
+    }),
+  ])
+
+  return res.status(200).json({ success: true })
+})

--- a/pages/api/submit-vote.ts
+++ b/pages/api/submit-vote.ts
@@ -2,6 +2,7 @@ import { validate as validateEmail } from 'email-validator'
 import { firestore } from 'firebase-admin'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { generateAuthToken } from 'src/crypto/generate-auth-tokens'
+import { is64HexChars } from 'src/crypto/replacement-key'
 import { CipherStrings } from 'src/crypto/stringify-shuffle'
 import { EncryptedVote } from 'src/status/AcceptedVotes'
 
@@ -11,12 +12,15 @@ import { pusher } from './pusher'
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const payload = req.method === 'POST' ? req.body : req.query
-  const { auth, election_id, embed = '' } = payload
+  const { auth, election_id, embed = '', replacement_pubkey } = payload
   if (!election_id) return res.status(400).json({ error: 'Missing Election ID' })
   if (embed) await pushover('Submitted Vote w/ embed', `election: ${election_id}\nembed: ${embed}\nauth: ${auth}`)
 
   let { encrypted_vote } = payload
   if (typeof encrypted_vote === 'string') encrypted_vote = JSON.parse(encrypted_vote)
+
+  if (!is64HexChars(replacement_pubkey))
+    return res.status(400).json({ error: 'Missing or malformed replacement_pubkey' })
 
   // return res.status(200).json({ auth, election_id, encrypted_vote })
 
@@ -43,6 +47,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           headers: req.headers,
           link_auth,
           rejection: message,
+          replacement_pubkey,
         }),
         pushover('Link submission when closed', `election: ${election_id}\nauth: ${auth}\nmessage: ${message}`),
       ])
@@ -58,6 +63,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         encrypted_vote,
         headers: req.headers,
         link_auth,
+        replacement_pubkey,
       }),
       // 2b. Update election's cached tally of num_votes
       electionDoc.update({
@@ -93,6 +99,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           encrypted_vote,
           headers: req.headers,
           rejection: message,
+          replacement_pubkey,
         }),
         pushover('SIV submission: Bad Auth Token', `election: ${election_id}\nauth: ${auth}\nmessage: ${message}`),
       ])
@@ -109,9 +116,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   await Promise.all([
     // 2a. Store the encrypted vote in db
-    electionDoc
-      .collection('votes')
-      .add({ auth, created_at: firestore.FieldValue.serverTimestamp(), encrypted_vote, headers: req.headers }),
+    electionDoc.collection('votes').add({
+      auth,
+      created_at: firestore.FieldValue.serverTimestamp(),
+      encrypted_vote,
+      headers: req.headers,
+      replacement_pubkey,
+    }),
     // 2b. Update elections cached tally of num_votes
     electionDoc.update({ num_votes: firestore.FieldValue.increment(1) }),
   ])

--- a/pages/api/submit-vote.ts
+++ b/pages/api/submit-vote.ts
@@ -7,10 +7,11 @@ import { CipherStrings } from 'src/crypto/stringify-shuffle'
 import { EncryptedVote } from 'src/status/AcceptedVotes'
 
 import { firebase, pushover, sendEmail } from './_services'
+import { withApiErrorLogs } from './_with-api-error-logs'
 import { validateAuthToken } from './check-auth-token'
 import { pusher } from './pusher'
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+export default withApiErrorLogs(async (req: NextApiRequest, res: NextApiResponse) => {
   const payload = req.method === 'POST' ? req.body : req.query
   const { auth, election_id, embed = '', replacement_pubkey } = payload
   if (!election_id) return res.status(400).json({ error: 'Missing Election ID' })
@@ -163,7 +164,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   await Promise.all(promises)
 
   res.status(200).send('Success.')
-}
+})
 
 const buildSubmissionReceipt = (auth: string, encrypted_vote: Record<string, CipherStrings>) =>
   Buffer.from(`

--- a/src/admin/Voters/ExistingVoters.tsx
+++ b/src/admin/Voters/ExistingVoters.tsx
@@ -4,6 +4,7 @@ import { useStored } from '../useStored'
 import { InvalidVotersTable } from './InvalidVotersTable'
 import { NumVotedRow } from './NumVotedRow'
 import { getStatus } from './Signature'
+import { StrengthenedCounts } from './StrengthenedCounts'
 import { TopBarButtons } from './TopBarButtons'
 import { UnlockedStatus } from './UnlockedStatus'
 import { use_latest_mailgun_events } from './use-latest-mailgun-events'
@@ -39,6 +40,7 @@ export const ExistingVoters = () => {
       {/* Group around Accepted Voters table */}
       <div className="pt-3 pb-1 pl-4 mt-8 -ml-4 rounded shadow-md bg-blue-200/40">
         <UnlockedStatus />
+        <StrengthenedCounts />
         <div className="pr-4">
           <TopBarButtons
             {...{

--- a/src/admin/Voters/StrengthenedCounts.tsx
+++ b/src/admin/Voters/StrengthenedCounts.tsx
@@ -1,0 +1,26 @@
+import { useStored } from '../useStored'
+
+/** Shown only when unlockable ciphertext has changed since last unlock — actionable for re-unlock timing. */
+export const StrengthenedCounts = () => {
+  const { last_decrypted_at, num_strengthened_since_unlock = 0 } = useStored()
+
+  if (!last_decrypted_at || num_strengthened_since_unlock < 1) return null
+
+  const suggestWait = num_strengthened_since_unlock < 5
+
+  return (
+    <div className="mr-4 mb-3.5 rounded-md border border-solid border-black/15 bg-black/[0.03] p-2.5">
+      <p className="m-0 text-[13px]">
+        <span className="font-medium text-black/70">
+          {num_strengthened_since_unlock} vote{num_strengthened_since_unlock === 1 ? '' : 's'} strengthened
+        </span>
+        <span className="text-black/55"> since last unlock</span>
+      </p>
+      {suggestWait && (
+        <p className="m-0 mt-1 text-[12px] text-black/45">
+          Wait for a few strengthens before re-unlocking so a single change isn&apos;t identifying.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/crypto/replacement-key.test.ts
+++ b/src/crypto/replacement-key.test.ts
@@ -2,7 +2,14 @@ import { getPublicKey } from '@noble/ed25519'
 import { describe, expect, test } from 'bun:test'
 
 import { bytesToHex, hexToBytes } from './bytes-to-hex'
-import { generateReplacementKeypair, is64HexChars } from './replacement-key'
+import {
+  encodeReplacementPayload,
+  generateReplacementKeypair,
+  is64HexChars,
+  is128HexChars,
+  signReplacement,
+  verifyReplacement,
+} from './replacement-key'
 
 describe('generateReplacementKeypair', () => {
   test('returns 32-byte hex keys that match', async () => {
@@ -13,10 +20,51 @@ describe('generateReplacementKeypair', () => {
     expect(replacement_pubkey).toBe(bytesToHex(await getPublicKey(hexToBytes(replacement_privkey))))
   })
 
-  test('isReplacementPubkey rejects bad values', () => {
+  test('is64HexChars rejects bad values', () => {
     expect(is64HexChars(undefined)).toBe(false)
     expect(is64HexChars('abcd')).toBe(false)
     expect(is64HexChars('g'.repeat(64))).toBe(false)
     expect(is64HexChars('a'.repeat(63))).toBe(false)
+  })
+})
+
+describe('signReplacement / verifyReplacement', async () => {
+  const { replacement_privkey, replacement_pubkey } = await generateReplacementKeypair()
+  const encrypted_vote = { mayor: { encrypted: 'aa', lock: 'bb' }, prop: { encrypted: 'cc', lock: 'dd' } }
+  const message = encodeReplacementPayload({ auth: 'abcd123456', election_id: 'e1', encrypted_vote })
+  const signature = await signReplacement(replacement_privkey, message)
+
+  test('valid signature verifies', async () => {
+    expect(is128HexChars(signature)).toBe(true)
+    expect(await verifyReplacement(replacement_pubkey, signature, message)).toBe(true)
+  })
+
+  test('encodeReplacementPayload produces canonical bytes, no matter object order', () => {
+    // Same fields, opposite key insertion order
+    const shuffledVote = {
+      prop: { encrypted: 'cc', lock: 'dd' },
+      // eslint-disable-next-line perfectionist/sort-objects -- intentional
+      mayor: { encrypted: 'aa', lock: 'bb' },
+    }
+
+    // Confirm key-order is different
+    expect(Object.keys(shuffledVote)).not.toEqual(Object.keys(encrypted_vote))
+
+    // Encoding should still match
+    const shuffled = encodeReplacementPayload({
+      auth: 'abcd123456',
+      election_id: 'e1',
+      encrypted_vote: shuffledVote,
+    })
+    expect([...message]).toEqual([...shuffled])
+  })
+
+  test('tampered encrypted_vote does not verify', async () => {
+    const tampered = encodeReplacementPayload({
+      auth: 'abcd123456',
+      election_id: 'e1',
+      encrypted_vote: { ...encrypted_vote, mayor: { encrypted: 'zz', lock: 'bb' } },
+    })
+    expect(await verifyReplacement(replacement_pubkey, signature, tampered)).toBe(false)
   })
 })

--- a/src/crypto/replacement-key.test.ts
+++ b/src/crypto/replacement-key.test.ts
@@ -1,0 +1,22 @@
+import { getPublicKey } from '@noble/ed25519'
+import { describe, expect, test } from 'bun:test'
+
+import { bytesToHex, hexToBytes } from './bytes-to-hex'
+import { generateReplacementKeypair, is64HexChars } from './replacement-key'
+
+describe('generateReplacementKeypair', () => {
+  test('returns 32-byte hex keys that match', async () => {
+    const { replacement_privkey, replacement_pubkey } = await generateReplacementKeypair()
+
+    expect(is64HexChars(replacement_privkey)).toBe(true)
+    expect(is64HexChars(replacement_pubkey)).toBe(true)
+    expect(replacement_pubkey).toBe(bytesToHex(await getPublicKey(hexToBytes(replacement_privkey))))
+  })
+
+  test('isReplacementPubkey rejects bad values', () => {
+    expect(is64HexChars(undefined)).toBe(false)
+    expect(is64HexChars('abcd')).toBe(false)
+    expect(is64HexChars('g'.repeat(64))).toBe(false)
+    expect(is64HexChars('a'.repeat(63))).toBe(false)
+  })
+})

--- a/src/crypto/replacement-key.ts
+++ b/src/crypto/replacement-key.ts
@@ -1,0 +1,18 @@
+import { getPublicKey, utils } from '@noble/ed25519'
+
+import { bytesToHex } from './bytes-to-hex'
+
+/** ed25519 keypair for authorizing later vote replacements (strengthen / selection update). */
+export async function generateReplacementKeypair() {
+  const privateKey = utils.randomPrivateKey()
+  const publicKey = await getPublicKey(privateKey)
+  return {
+    replacement_privkey: bytesToHex(privateKey),
+    replacement_pubkey: bytesToHex(publicKey),
+  }
+}
+
+/** 32-byte ed25519 public key as lowercase hex. */
+export function is64HexChars(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)
+}

--- a/src/crypto/replacement-key.ts
+++ b/src/crypto/replacement-key.ts
@@ -1,6 +1,27 @@
-import { getPublicKey, utils } from '@noble/ed25519'
+import { getPublicKey, sign, utils, verify } from '@noble/ed25519'
+import { CipherStrings } from 'src/crypto/stringify-shuffle'
 
-import { bytesToHex } from './bytes-to-hex'
+import { bytesToHex, hexToBytes } from './bytes-to-hex'
+
+/** Canonical bytes the client signs and the server verifies for a vote replace. */
+export function encodeReplacementPayload({
+  auth,
+  election_id,
+  encrypted_vote,
+}: {
+  auth: string
+  election_id: string
+  encrypted_vote: Record<string, CipherStrings>
+}) {
+  const sorted = Object.keys(encrypted_vote)
+    .sort()
+    .reduce((acc, key) => {
+      const { encrypted, lock } = encrypted_vote[key]
+      acc[key] = { encrypted, lock }
+      return acc
+    }, {} as Record<string, CipherStrings>)
+  return new TextEncoder().encode(JSON.stringify({ auth, election_id, encrypted_vote: sorted }))
+}
 
 /** ed25519 keypair for authorizing later vote replacements (strengthen / selection update). */
 export async function generateReplacementKeypair() {
@@ -12,7 +33,20 @@ export async function generateReplacementKeypair() {
   }
 }
 
-/** 32-byte ed25519 public key as lowercase hex. */
+/** 32-byte ed25519 key material as lowercase hex. */
 export function is64HexChars(value: unknown): value is string {
   return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)
+}
+
+/** 64-byte ed25519 signature as lowercase hex. */
+export function is128HexChars(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{128}$/.test(value)
+}
+
+export async function signReplacement(privkeyHex: string, message: Uint8Array) {
+  return bytesToHex(await sign(message, hexToBytes(privkeyHex)))
+}
+
+export async function verifyReplacement(pubkeyHex: string, signatureHex: string, message: Uint8Array) {
+  return verify(hexToBytes(signatureHex), message, hexToBytes(pubkeyHex))
 }

--- a/src/malware-check/InitMalwareCheck.tsx
+++ b/src/malware-check/InitMalwareCheck.tsx
@@ -177,11 +177,7 @@ export const MalwareCheck = ({
 
           {panel === 'customize' && (
             <div className="mt-4">
-              <CustomizeVerificationNumber
-                onCancel={() => setPanel(null)}
-                startOpen
-                {...{ dispatch, state }}
-              />
+              <CustomizeVerificationNumber onCancel={() => setPanel(null)} startOpen {...{ dispatch, state }} />
             </div>
           )}
 
@@ -198,41 +194,41 @@ export const MalwareCheck = ({
                   <MalwareCheckQRCode url={qrUrl} />
                 )}
 
-              <div className="max-w-sm">
-                <p className="mb-3">
-                  As an additional layer of security, you can use multiple&nbsp;devices to verify your vote was submitted
-                  as intended.
-                </p>
-
-                <p className="text-[11px] text-black/60">
-                  <span className="font-medium text-black/70">How it works:</span> This rebuilds your encrypted vote
-                  submission, then lets you confirm the selections are as you intended.
-                </p>
-
-                <p className="mb-2 text-[11px] text-black/50">⚠️ This QR contains your private vote selections.</p>
-
-                <a
-                  className="text-[11px] mt-7 block"
-                  href="https://docs.siv.org/verifiability/detecting-malware"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Learn more →
-                </a>
-                {checkStatus && checkStatus.verified_count > 0 && (
-                  <p className="mt-2 text-sm text-green-600">
-                    Verified with {checkStatus.verified_count} separate device
-                    {checkStatus.verified_count > 1 ? 's' : ''}
-                    {checkStatus.checks
-                      .filter((c) => c.confirmed === true)
-                      .slice(0, 1)
-                      .map((c) => ` - ${c.device_info}`)
-                      .join(', ')}
+                <div className="max-w-sm">
+                  <p className="mb-3">
+                    As an additional layer of security, you can use multiple&nbsp;devices to verify your vote was
+                    submitted as intended.
                   </p>
-                )}
+
+                  <p className="text-[11px] text-black/60">
+                    <span className="font-medium text-black/70">How it works:</span> This rebuilds your encrypted vote
+                    submission, then lets you confirm the selections are as you intended.
+                  </p>
+
+                  <p className="mb-2 text-[11px] text-black/50">⚠️ This QR contains your private vote selections.</p>
+
+                  <a
+                    className="text-[11px] mt-7 block"
+                    href="https://docs.siv.org/verifiability/detecting-malware"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more →
+                  </a>
+                  {checkStatus && checkStatus.verified_count > 0 && (
+                    <p className="mt-2 text-sm text-green-600">
+                      Verified with {checkStatus.verified_count} separate device
+                      {checkStatus.verified_count > 1 ? 's' : ''}
+                      {checkStatus.checks
+                        .filter((c) => c.confirmed === true)
+                        .slice(0, 1)
+                        .map((c) => ` - ${c.device_info}`)
+                        .join(', ')}
+                    </p>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            ))}
         </>
       )}
     </div>

--- a/src/malware-check/InitMalwareCheck.tsx
+++ b/src/malware-check/InitMalwareCheck.tsx
@@ -177,7 +177,7 @@ export const MalwareCheck = ({
 
           {panel === 'customize' && (
             <div className="mt-4">
-              <CustomizeVerificationNumber onCancel={() => setPanel(null)} startOpen {...{ dispatch, state }} />
+              <CustomizeVerificationNumber onCancel={() => setPanel(null)} startOpen {...{ auth, dispatch, election_id, state }} />
             </div>
           )}
 

--- a/src/malware-check/InitMalwareCheck.tsx
+++ b/src/malware-check/InitMalwareCheck.tsx
@@ -26,7 +26,7 @@ type StatusResponse = {
 const LOCALHOST_IP = '192.168.4.124'
 
 const panelBtn =
-  'flex flex-1 items-center justify-center gap-2 rounded-lg border border-solid px-3 py-3 text-[13px] font-medium cursor-pointer transition-colors'
+  'flex flex-1 items-center justify-center gap-2 rounded-lg border border-solid px-3 py-4 text-[13px] font-medium cursor-pointer transition-colors'
 
 export const MalwareCheck = ({
   auth,

--- a/src/malware-check/InitMalwareCheck.tsx
+++ b/src/malware-check/InitMalwareCheck.tsx
@@ -1,3 +1,4 @@
+import { PenLine, Smartphone } from 'lucide-react'
 import { Dispatch, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'src/admin/Spinner'
 import { api } from 'src/api-helper'
@@ -16,12 +17,16 @@ type CheckStatus = {
   user_agent: string
 }
 
+type Panel = 'customize' | 'device' | null
+
 type StatusResponse = {
   checks: CheckStatus[]
   verified_count: number
 }
-
 const LOCALHOST_IP = '192.168.4.124'
+
+const panelBtn =
+  'flex flex-1 items-center justify-center gap-2 rounded-lg border border-solid px-3 py-3 text-[13px] font-medium cursor-pointer transition-colors'
 
 export const MalwareCheck = ({
   auth,
@@ -35,6 +40,7 @@ export const MalwareCheck = ({
   state: State & { submitted_at?: Date }
 }) => {
   const [isOpen, setIsOpen] = useState(false)
+  const [panel, setPanel] = useState<Panel>(null)
   const [checkStatus] = useState<null | StatusResponse>(null)
   const [keyBase64URL, setKeyBase64URL] = useState<null | string>(null)
   const [otp, setOtp] = useState<null | string>(null)
@@ -65,7 +71,7 @@ export const MalwareCheck = ({
 
   // Generate symmetric key, encrypt payload, and get OTP from server
   useEffect(() => {
-    if (!isOpen) return
+    if (panel !== 'device') return
 
     if (!state.randomizer || otp || isLoading) return
     ;(async () => {
@@ -117,7 +123,7 @@ export const MalwareCheck = ({
         setIsLoading(false)
       }
     })()
-  }, [state.randomizer, auth, election_id, otp, isLoading, isOpen])
+  }, [state.randomizer, auth, election_id, otp, isLoading, panel])
 
   const qrUrl = useMemo(() => {
     if (!state.randomizer || !keyBase64URL || !otp) return ''
@@ -128,28 +134,69 @@ export const MalwareCheck = ({
     return `${protocol}//${host}/malware-check/${election_id}/${auth}/${otp}#${keyBase64URL}`
   }, [auth, election_id, state.randomizer, keyBase64URL, otp])
 
+  const toggleOpen = () => {
+    if (isOpen) setPanel(null)
+    setIsOpen(!isOpen)
+  }
+
   return (
     <div>
       <p className="py-6 mt-5 text-[12px]">
-        <a className="cursor-pointer text-blue-500/90" onClick={() => setIsOpen(!isOpen)}>
+        <a className="cursor-pointer text-blue-500/90" onClick={toggleOpen}>
           {isOpen ? '[-]' : '[+]'} Verify your vote {"wasn't"} changed by malware
         </a>
       </p>
       {isOpen && (
         <>
-          <CustomizeVerificationNumber {...{ dispatch, state }} />
+          <div className="flex flex-col gap-2 sm:flex-row sm:gap-3">
+            <button
+              className={`${panelBtn} ${
+                panel === 'device'
+                  ? 'border-blue-500/50 bg-blue-50 text-blue-700'
+                  : 'border-black/15 bg-white text-black/80 hover:border-black/30'
+              }`}
+              onClick={() => setPanel('device')}
+              type="button"
+            >
+              <Smartphone className="size-4 opacity-70" strokeWidth={1.75} />
+              Check with another device
+            </button>
+            <button
+              className={`${panelBtn} ${
+                panel === 'customize'
+                  ? 'border-h26-green/40 bg-h26-green/5 text-h26-green'
+                  : 'border-black/15 bg-white text-black/80 hover:border-black/30'
+              }`}
+              onClick={() => setPanel('customize')}
+              type="button"
+            >
+              <PenLine className="size-4 opacity-70" strokeWidth={1.75} />
+              Customize your Verification Number
+            </button>
+          </div>
 
-          {qrError ? (
-            <p className="mb-2 text-xs text-red-600">⚠️ {qrError}</p>
-          ) : (
-            <div className="flex gap-4 items-center mt-4">
-              {isLoading || !qrUrl ? (
-                <div className="flex flex-col gap-4 items-center p-4 mb-2 text-xs rounded-md border border-solid text-black/50 border-black/15 h-[230px] w-[172px] justify-center">
-                  <Spinner /> Loading QR...
-                </div>
-              ) : (
-                <MalwareCheckQRCode url={qrUrl} />
-              )}
+          {panel === 'customize' && (
+            <div className="mt-4">
+              <CustomizeVerificationNumber
+                onCancel={() => setPanel(null)}
+                startOpen
+                {...{ dispatch, state }}
+              />
+            </div>
+          )}
+
+          {panel === 'device' &&
+            (qrError ? (
+              <p className="mt-4 mb-2 text-xs text-red-600">⚠️ {qrError}</p>
+            ) : (
+              <div className="flex gap-4 items-center mt-4">
+                {isLoading || !qrUrl ? (
+                  <div className="flex flex-col gap-4 items-center p-4 mb-2 text-xs rounded-md border border-solid text-black/50 border-black/15 h-[230px] w-[172px] justify-center">
+                    <Spinner /> Loading QR...
+                  </div>
+                ) : (
+                  <MalwareCheckQRCode url={qrUrl} />
+                )}
 
               <div className="max-w-sm">
                 <p className="mb-3">

--- a/src/malware-check/InitMalwareCheck.tsx
+++ b/src/malware-check/InitMalwareCheck.tsx
@@ -25,10 +25,12 @@ const LOCALHOST_IP = '192.168.4.124'
 
 export const MalwareCheck = ({
   auth,
+  dispatch,
   election_id,
   state,
 }: {
   auth: string
+  dispatch: Dispatch<Record<string, string>>
   election_id: string
   state: State & { submitted_at?: Date }
 }) => {
@@ -149,40 +151,43 @@ export const MalwareCheck = ({
                 <MalwareCheckQRCode url={qrUrl} />
               )}
 
-            <div className="max-w-sm">
-              <p className="mb-3">
-                As an additional layer of security, you can use multiple&nbsp;devices to verify your vote was submitted
-                as intended.
-              </p>
-
-              <p className="text-[11px] text-black/60">
-                <span className="font-medium text-black/70">How it works:</span> This rebuilds your encrypted vote
-                submission, then lets you confirm the selections are as you intended.
-              </p>
-
-              <p className="mb-2 text-[11px] text-black/50">⚠️ This QR contains your private vote selections.</p>
-
-              <a
-                className="text-[11px] mt-7 block"
-                href="https://docs.siv.org/verifiability/detecting-malware"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Learn more →
-              </a>
-              {checkStatus && checkStatus.verified_count > 0 && (
-                <p className="mt-2 text-sm text-green-600">
-                  Verified with {checkStatus.verified_count} separate device{checkStatus.verified_count > 1 ? 's' : ''}
-                  {checkStatus.checks
-                    .filter((c) => c.confirmed === true)
-                    .slice(0, 1)
-                    .map((c) => ` - ${c.device_info}`)
-                    .join(', ')}
+              <div className="max-w-sm">
+                <p className="mb-3">
+                  As an additional layer of security, you can use multiple&nbsp;devices to verify your vote was submitted
+                  as intended.
                 </p>
-              )}
+
+                <p className="text-[11px] text-black/60">
+                  <span className="font-medium text-black/70">How it works:</span> This rebuilds your encrypted vote
+                  submission, then lets you confirm the selections are as you intended.
+                </p>
+
+                <p className="mb-2 text-[11px] text-black/50">⚠️ This QR contains your private vote selections.</p>
+
+                <a
+                  className="text-[11px] mt-7 block"
+                  href="https://docs.siv.org/verifiability/detecting-malware"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more →
+                </a>
+                {checkStatus && checkStatus.verified_count > 0 && (
+                  <p className="mt-2 text-sm text-green-600">
+                    Verified with {checkStatus.verified_count} separate device
+                    {checkStatus.verified_count > 1 ? 's' : ''}
+                    {checkStatus.checks
+                      .filter((c) => c.confirmed === true)
+                      .slice(0, 1)
+                      .map((c) => ` - ${c.device_info}`)
+                      .join(', ')}
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/src/malware-check/InitMalwareCheck.tsx
+++ b/src/malware-check/InitMalwareCheck.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
+import { Dispatch, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'src/admin/Spinner'
 import { api } from 'src/api-helper'
 import { encryptSymmetric, exportKeyToBase64URL, generateSymmetricKey } from 'src/crypto/symmetric-encrypt'
 
 import { bigintToBase64URL } from '../vote/submitted/base64url'
+import { CustomizeVerificationNumber } from '../vote/submitted/CustomizeVerificationNumber'
 import { State } from '../vote/vote-state'
 import { MalwareCheckQRCode } from './MalwareCheckQRCode'
 
@@ -132,18 +133,21 @@ export const MalwareCheck = ({
           {isOpen ? '[-]' : '[+]'} Verify your vote {"wasn't"} changed by malware
         </a>
       </p>
-      {isOpen &&
-        (qrError ? (
-          <p className="mb-2 text-xs text-red-600">⚠️ {qrError}</p>
-        ) : (
-          <div className="flex gap-4 items-center">
-            {isLoading || !qrUrl ? (
-              <div className="flex flex-col gap-4 items-center p-4 mb-2 text-xs rounded-md border border-solid text-black/50 border-black/15 h-[230px] w-[172px] justify-center">
-                <Spinner /> Loading QR...
-              </div>
-            ) : (
-              <MalwareCheckQRCode url={qrUrl} />
-            )}
+      {isOpen && (
+        <>
+          <CustomizeVerificationNumber {...{ dispatch, state }} />
+
+          {qrError ? (
+            <p className="mb-2 text-xs text-red-600">⚠️ {qrError}</p>
+          ) : (
+            <div className="flex gap-4 items-center mt-4">
+              {isLoading || !qrUrl ? (
+                <div className="flex flex-col gap-4 items-center p-4 mb-2 text-xs rounded-md border border-solid text-black/50 border-black/15 h-[230px] w-[172px] justify-center">
+                  <Spinner /> Loading QR...
+                </div>
+              ) : (
+                <MalwareCheckQRCode url={qrUrl} />
+              )}
 
             <div className="max-w-sm">
               <p className="mb-3">

--- a/src/vote/AirGappedSubmission.tsx
+++ b/src/vote/AirGappedSubmission.tsx
@@ -35,7 +35,7 @@ export const AirGappedSubmission = ({
 
   const submission_url = `/api/submit-vote?auth=${auth}&election_id=${election_id}&encrypted_vote=${JSON.stringify(
     sortedKeys(state.encrypted),
-  )}`
+  )}&replacement_pubkey=${state.replacement_pubkey || ''}`
 
   return (
     <div className="px-3 py-2 mt-3 rounded-lg shadow-lg bg-yellow-200/50">

--- a/src/vote/AuthenticatedContent.tsx
+++ b/src/vote/AuthenticatedContent.tsx
@@ -54,7 +54,7 @@ export const AuthenticatedContent = ({ auth, election_id }: { auth: string; elec
               <title key="title">SIV: Vote Submitted</title>
             </Head>
             <h1>Vote Submitted.</h1>
-            <SubmittedScreen {...{ auth, election_id, state }} />
+            <SubmittedScreen {...{ auth, dispatch, election_id, state }} />
           </>
         )
       ) : (

--- a/src/vote/AuthenticatedContent.tsx
+++ b/src/vote/AuthenticatedContent.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect, useRef } from 'react'
+import { generateReplacementKeypair } from 'src/crypto/replacement-key'
 
 import { GlobalCSS } from '../GlobalCSS'
 import { CustomAuthFlow, hasCustomAuthFlow } from './auth/11choosesAuth/CustomAuthFlow'
@@ -22,6 +23,13 @@ export const AuthenticatedContent = ({ auth, election_id }: { auth: string; elec
   const wasAlreadySubmittedOnPageLoad = useRef(!!state.submitted_at && !!state.link_auth).current
 
   storeElectionInfo(dispatch, election_id)
+
+  // Generate replacement keypair on load
+  useEffect(() => {
+    if (state.replacement_privkey && state.replacement_pubkey) return
+    if (state.submitted_at) return // don't invent a new keypair after submit — it wouldn't match the server
+    generateReplacementKeypair().then(dispatch)
+  }, [dispatch, state.replacement_privkey, state.replacement_pubkey, state.submitted_at])
 
   // Keep link_auth in localStorage and restore it on the URL for subsequent visits
   useEffect(() => {

--- a/src/vote/SubmitButton.tsx
+++ b/src/vote/SubmitButton.tsx
@@ -33,6 +33,7 @@ export const SubmitButton = ({
     // Check if all expected columns exist in state.encrypted
     const allPresent = expectedColumns.every((columnId) => state.encrypted[columnId])
     if (!allPresent) return
+    if (!state.replacement_pubkey) return
     ;(async () => {
       // All columns are present, submit now
       const response = await api('submit-vote', {
@@ -40,6 +41,7 @@ export const SubmitButton = ({
         election_id,
         embed,
         encrypted_vote: state.encrypted,
+        replacement_pubkey: state.replacement_pubkey,
       })
 
       // Stop if there was an error
@@ -79,7 +81,7 @@ export const SubmitButton = ({
       // Scroll page to top
       window.scrollTo(0, 0)
     })()
-  }, [expectedColumns, state.encrypted, auth, election_id, embed, dispatch])
+  }, [expectedColumns, state.encrypted, state.replacement_pubkey, auth, election_id, embed, dispatch])
 
   return (
     <>
@@ -90,6 +92,7 @@ export const SubmitButton = ({
           disabled={
             !state.ballot_design_finalized ||
             !state.public_key ||
+            !state.replacement_pubkey ||
             Object.values(state.plaintext).filter((v) => v !== 'BLANK').length === 0 ||
             buttonText !== 'Submit'
           }

--- a/src/vote/strengthen-tracking.test.ts
+++ b/src/vote/strengthen-tracking.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+
+import { strengthenTracking } from './strengthen-tracking'
+
+describe('strengthenTracking', () => {
+  test('adds into the last 4 digits', () => {
+    expect(strengthenTracking('1111-1111-1111', '1234')).toBe('1111-1111-2345')
+  })
+
+  test('wraps mod 10000', () => {
+    expect(strengthenTracking('1111-1111-9999', '0005')).toBe('1111-1111-0004')
+  })
+
+  test('pads short voter digits', () => {
+    expect(strengthenTracking('2222-3333-4444', '7')).toBe('2222-3333-4451')
+  })
+
+  test('strips non-digits from inputs', () => {
+    expect(strengthenTracking('1111-1111-1111', '12-34')).toBe('1111-1111-2345')
+  })
+})

--- a/src/vote/strengthen-tracking.ts
+++ b/src/vote/strengthen-tracking.ts
@@ -1,0 +1,7 @@
+/** Add voter-chosen 4 digits into the last group of a ####-####-#### verification number. */
+export function strengthenTracking(deviceTracking: string, voterDigits: string): string {
+  const parts = deviceTracking.replace(/\D/g, '').padStart(12, '0').slice(0, 12)
+  const add = Number(voterDigits.replace(/\D/g, '').slice(0, 4).padStart(4, '0'))
+  const sum = String((Number(parts.slice(8, 12)) + add) % 10_000).padStart(4, '0')
+  return `${parts.slice(0, 4)}-${parts.slice(4, 8)}-${sum}`
+}

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -258,6 +258,7 @@ export function CustomizeVerificationNumber({
                   <span className="pr-2 text-[0.85rem] text-h26-muted sm:pr-0 sm:text-[0.95rem]">You add</span>
                   <span />
                   <input
+                    autoComplete="off"
                     className="box-border h-11 w-full rounded-lg border border-black/10 bg-white font-mono26 text-[1.05rem] tracking-[0.08em] text-center text-h26-text tabular-nums outline-none transition-shadow focus:border-h26-green/45 focus:shadow-[0_0_0_4px_rgba(26,107,74,0.12)] sm:h-12 sm:text-[1.35rem] sm:tracking-[0.12em]"
                     inputMode="numeric"
                     maxLength={4}

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -3,6 +3,7 @@ import { Dispatch, useEffect, useRef, useState } from 'react'
 import { api } from 'src/api-helper'
 import { encodeReplacementPayload, signReplacement } from 'src/crypto/replacement-key'
 import { h26fonts } from 'src/homepage2026/fonts'
+import { useElectionInfo } from 'src/status/use-election-info'
 
 import { strengthenTracking } from '../strengthen-tracking'
 import { State } from '../vote-state'
@@ -33,6 +34,14 @@ export function CustomizeVerificationNumber({
   const [error, setError] = useState('')
   const pendingTracking = useRef<null | string>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  // Show caveat only if last strengthen is newer than the unlocked snapshot
+  const { last_decrypted_at } = useElectionInfo()
+  const lastStrengthenedAt = state.previous_submissions?.at(-1)?.replaced_at
+  const awaitingReunlock =
+    !!last_decrypted_at &&
+    !!lastStrengthenedAt &&
+    new Date(lastStrengthenedAt).getTime() > new Date(last_decrypted_at).getTime()
 
   useEffect(() => {
     if (step === 'digits') inputRef.current?.focus()
@@ -112,9 +121,17 @@ export function CustomizeVerificationNumber({
       )}
 
       {step === 'done' && (
-        <div className="inline-flex items-center gap-1.5 text-[0.85rem] text-h26-green animate-[fadeInUp_0.5s_ease-out_both]">
-          <Check className="size-3.5" strokeWidth={2} />
-          <span className="font-medium">Your Verification Number is updated</span>
+        <div className="animate-[fadeInUp_0.5s_ease-out_both]">
+          <div className="inline-flex items-center gap-1.5 text-[0.85rem] text-h26-green">
+            <Check className="size-3.5" strokeWidth={2} />
+            <span className="font-medium">Your Verification Number is updated</span>
+          </div>
+          {awaitingReunlock && (
+            <p className="mt-1.5 max-w-md text-[0.75rem] leading-snug text-h26-muted">
+              Your new number won&apos;t be visible in the published results until the administrator shuffles &amp;
+              unlocks votes again.
+            </p>
+          )}
         </div>
       )}
 

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -66,7 +66,7 @@ export function CustomizeVerificationNumber({
       {step === 'done' && (
         <div className="inline-flex items-center gap-1.5 text-[0.85rem] text-h26-green animate-[fadeInUp_0.5s_ease-out_both]">
           <Check className="size-3.5" strokeWidth={2} />
-          <span className="font-medium">Customized</span>
+          <span className="font-medium">Your Verification Number is updated</span>
         </div>
       )}
 

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -82,7 +82,6 @@ export function CustomizeVerificationNumber({
             'animate-[fadeInUp_0.45s_ease-out_both]',
           ].join(' ')}
         >
-          <span className="font-mono26 text-[0.65rem] uppercase tracking-[0.2em] text-h26-green">Optional</span>
           <h4 className="mt-2 mb-0 font-serif26 text-[1.35rem] font-normal tracking-tight text-h26-text md:text-[1.5rem]">
             Customize
           </h4>

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -44,7 +44,7 @@ export function CustomizeVerificationNumber({
   }
 
   return (
-    <div className={`mt-1 w-full max-w-full min-w-0 ${h26fonts}`}>
+    <div className={`mt-1 w-full min-w-0 max-w-full ${h26fonts}`}>
       {step === 'closed' && (
         <button
           className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.85rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
@@ -89,7 +89,7 @@ export function CustomizeVerificationNumber({
               <p className="mt-6 mb-0 text-center font-mono26 text-[1.25rem] tracking-[0.06em] text-h26-text tabular-nums sm:text-[1.6rem] sm:tracking-[0.1em] md:text-[1.75rem]">
                 {device}
               </p>
-              <div className="mt-7 flex flex-wrap items-center gap-4">
+              <div className="flex flex-wrap gap-4 items-center mt-7">
                 <button
                   className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
                   onClick={() => setStep('digits')}
@@ -140,19 +140,23 @@ export function CustomizeVerificationNumber({
 
                   <span className="pr-2 text-[0.85rem] text-h26-muted sm:pr-0 sm:text-[0.95rem]">Result</span>
                   <span
-                    className={`min-w-0 font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-right sm:text-[1.35rem] sm:tracking-[0.08em] ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
+                    className={`min-w-0 font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-right sm:text-[1.35rem] sm:tracking-[0.08em] ${
+                      preview ? 'font-medium text-h26-text' : 'text-h26-text'
+                    }`}
                   >
                     {r1}-{r2}-
                   </span>
                   <span
-                    className={`font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-center sm:text-[1.35rem] sm:tracking-[0.08em] ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
+                    className={`font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-center sm:text-[1.35rem] sm:tracking-[0.08em] ${
+                      preview ? 'font-medium text-h26-text' : 'text-h26-text'
+                    }`}
                   >
                     {r3}
                   </span>
                 </div>
               </div>
 
-              <div className="mt-6 flex flex-wrap items-center gap-4">
+              <div className="flex flex-wrap gap-4 items-center mt-6">
                 <button
                   className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
                   disabled={!preview}

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -15,45 +15,26 @@ export function CustomizeVerificationNumber({
   state: State
 }) {
   const [step, setStep] = useState<Step>(state.tracking_customized_at ? 'done' : 'closed')
-  const [digits, setDigits] = useState(['', '', '', ''])
+  const [digits, setDigits] = useState('')
   const [deviceSnapshot, setDeviceSnapshot] = useState(state.tracking || '')
-  const inputsRef = useRef<(HTMLInputElement | null)[]>([])
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if (step === 'digits') inputsRef.current[0]?.focus()
+    if (step === 'digits') inputRef.current?.focus()
   }, [step])
 
   if (!state.tracking) return null
 
-  const digitString = digits.join('')
-  const preview = digitString.length === 4 ? strengthenTracking(deviceSnapshot, digitString) : null
+  const device = deviceSnapshot.padStart(14, '0')
+  const preview = digits.length === 4 ? strengthenTracking(deviceSnapshot, digits) : null
+  const [d1, d2, d3] = device.split('-')
+  const [r1, r2, r3] = (preview ?? '····-····-····').split('-')
 
   const open = () => {
     if (!state.tracking) return
     setDeviceSnapshot(state.tracking)
-    setDigits(['', '', '', ''])
+    setDigits('')
     setStep('write-down')
-  }
-
-  const setDigit = (index: number, raw: string) => {
-    const char = raw.replace(/\D/g, '').slice(-1)
-    const next = [...digits]
-    next[index] = char
-    setDigits(next)
-    if (char && index < 3) inputsRef.current[index + 1]?.focus()
-  }
-
-  const onDigitKeyDown = (index: number, key: string) => {
-    if (key === 'Backspace' && !digits[index] && index > 0) inputsRef.current[index - 1]?.focus()
-  }
-
-  const onDigitPaste = (text: string) => {
-    const chars = text.replace(/\D/g, '').slice(0, 4).split('')
-    if (!chars.length) return
-    const next = ['', '', '', '']
-    chars.forEach((c, i) => (next[i] = c))
-    setDigits(next)
-    inputsRef.current[Math.min(chars.length, 3)]?.focus()
   }
 
   const apply = () => {
@@ -63,10 +44,10 @@ export function CustomizeVerificationNumber({
   }
 
   return (
-    <div className={`mt-0.5 ${h26fonts}`}>
+    <div className={`mt-1 ${h26fonts}`}>
       {step === 'closed' && (
         <button
-          className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
+          className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.85rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
           onClick={open}
           type="button"
         >
@@ -76,7 +57,7 @@ export function CustomizeVerificationNumber({
       )}
 
       {step === 'done' && (
-        <div className="inline-flex items-center gap-1.5 text-[0.78rem] text-h26-green animate-[fadeInUp_0.5s_ease-out_both]">
+        <div className="inline-flex items-center gap-1.5 text-[0.85rem] text-h26-green animate-[fadeInUp_0.5s_ease-out_both]">
           <Check className="size-3.5" strokeWidth={2} />
           <span className="font-medium">Customized</span>
         </div>
@@ -85,36 +66,36 @@ export function CustomizeVerificationNumber({
       {(step === 'write-down' || step === 'digits') && (
         <div
           className={[
-            'mt-1 max-w-md rounded-[18px] p-5 md:p-6',
-            'bg-white/70 border border-white/80',
+            'mt-1.5 max-w-lg rounded-[20px] p-6 md:p-7',
+            'bg-white/75 border border-white/80',
             'shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06),inset_0_1px_0_0_rgba(255,255,255,0.5)]',
             'backdrop-blur-md',
             'animate-[fadeInUp_0.45s_ease-out_both]',
           ].join(' ')}
         >
-          <span className="font-mono26 text-[0.58rem] uppercase tracking-[0.2em] text-h26-green">Optional</span>
-          <h4 className="mt-1.5 mb-0 font-serif26 text-[1.05rem] font-normal tracking-tight text-h26-text">
+          <span className="font-mono26 text-[0.65rem] uppercase tracking-[0.2em] text-h26-green">Optional</span>
+          <h4 className="mt-2 mb-0 font-serif26 text-[1.35rem] font-normal tracking-tight text-h26-text md:text-[1.5rem]">
             Customize
           </h4>
 
           {step === 'write-down' && (
             <div className="mt-4">
-              <p className="m-0 text-[0.82rem] leading-[1.6] text-h26-textSecondary">
+              <p className="m-0 text-[0.95rem] leading-[1.65] text-h26-textSecondary">
                 Write down your current verification number first — before entering any digits.
               </p>
-              <p className="mt-4 mb-0 text-center font-mono26 text-[1.35rem] tracking-[0.12em] text-h26-text tabular-nums">
-                {deviceSnapshot.padStart(14, '0')}
+              <p className="mt-6 mb-0 text-center font-mono26 text-[1.6rem] tracking-[0.1em] text-h26-text tabular-nums md:text-[1.75rem]">
+                {device}
               </p>
-              <div className="mt-5 flex items-center gap-3">
+              <div className="mt-7 flex items-center gap-4">
                 <button
-                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-5 py-2.5 font-sans text-[0.82rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
+                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
                   onClick={() => setStep('digits')}
                   type="button"
                 >
                   I wrote it down
                 </button>
                 <button
-                  className="border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
+                  className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
                   onClick={() => setStep('closed')}
                   type="button"
                 >
@@ -126,46 +107,54 @@ export function CustomizeVerificationNumber({
 
           {step === 'digits' && (
             <div className="mt-4">
-              <p className="m-0 text-[0.82rem] leading-[1.6] text-h26-textSecondary">
+              <p className="m-0 text-[0.95rem] leading-[1.65] text-h26-textSecondary">
                 Add any 4 digits. They&apos;ll be combined into the last group of your number.
               </p>
 
-              <div className="mt-5 grid gap-2.5 text-[0.8rem]">
-                <Row label="Device" value={deviceSnapshot.padStart(14, '0')} />
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-h26-muted shrink-0">You add</span>
-                  <div className="flex gap-1.5">
-                    {digits.map((d, i) => (
-                      <input
-                        className="h-10 w-9 rounded-lg border border-black/10 bg-white/90 text-center font-mono26 text-[1.05rem] text-h26-text outline-none transition-shadow focus:border-h26-green/40 focus:shadow-[0_0_0_3px_rgba(26,107,74,0.12)]"
-                        inputMode="numeric"
-                        key={i}
-                        maxLength={1}
-                        onChange={(e) => setDigit(i, e.target.value)}
-                        onKeyDown={(e) => onDigitKeyDown(i, e.key)}
-                        onPaste={(e) => {
-                          e.preventDefault()
-                          onDigitPaste(e.clipboardData.getData('text'))
-                        }}
-                        pattern="\d*"
-                        ref={(el) => {
-                          inputsRef.current[i] = el
-                        }}
-                        value={d}
-                      />
-                    ))}
-                  </div>
+              {/* Prefix + last-group columns: hyphens stay in the mono string so they align with digits */}
+              <div className="mt-5 overflow-x-auto rounded-2xl border border-black/[0.06] bg-h26-bg/90 px-5 py-5">
+                <div
+                  className="grid w-max min-w-full items-center gap-x-0 gap-y-5"
+                  style={{ gridTemplateColumns: '6.75rem auto 6.5rem' }}
+                >
+                  <span className="text-[0.95rem] text-h26-muted">Device</span>
+                  <span className="font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-h26-text text-right">
+                    {d1}-{d2}-
+                  </span>
+                  <span className="font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-h26-text text-center">
+                    {d3}
+                  </span>
+
+                  <span className="text-[0.95rem] text-h26-muted">You add</span>
+                  <span />
+                  <input
+                    className="box-border h-12 w-full rounded-lg border border-black/10 bg-white font-mono26 text-[1.35rem] tracking-[0.12em] text-center text-h26-text tabular-nums outline-none transition-shadow focus:border-h26-green/45 focus:shadow-[0_0_0_4px_rgba(26,107,74,0.12)]"
+                    inputMode="numeric"
+                    maxLength={4}
+                    onChange={(e) => setDigits(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                    pattern="\d*"
+                    placeholder="····"
+                    ref={inputRef}
+                    value={digits}
+                  />
+
+                  <span className="text-[0.95rem] text-h26-muted">Result</span>
+                  <span
+                    className={`font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-right ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
+                  >
+                    {r1}-{r2}-
+                  </span>
+                  <span
+                    className={`font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-center ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
+                  >
+                    {r3}
+                  </span>
                 </div>
-                <Row
-                  emphasize
-                  label="Result"
-                  value={preview?.padStart(14, '0') ?? '····-····-····'}
-                />
               </div>
 
-              <div className="mt-5 flex items-center gap-3">
+              <div className="mt-6 flex items-center gap-4">
                 <button
-                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-5 py-2.5 font-sans text-[0.82rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
+                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
                   disabled={!preview}
                   onClick={apply}
                   type="button"
@@ -173,7 +162,7 @@ export function CustomizeVerificationNumber({
                   Apply
                 </button>
                 <button
-                  className="border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
+                  className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
                   onClick={() => setStep('write-down')}
                   type="button"
                 >
@@ -184,22 +173,6 @@ export function CustomizeVerificationNumber({
           )}
         </div>
       )}
-    </div>
-  )
-}
-
-function Row({ emphasize, label, value }: { emphasize?: boolean; label: string; value: string }) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-h26-muted shrink-0">{label}</span>
-      <span
-        className={[
-          'font-mono26 tracking-[0.08em] tabular-nums',
-          emphasize ? 'text-h26-text font-medium' : 'text-h26-textSecondary',
-        ].join(' ')}
-      >
-        {value}
-      </span>
     </div>
   )
 }

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -92,20 +92,20 @@ export function CustomizeVerificationNumber({
               <p className="mt-6 mb-0 text-center font-mono26 text-[1.25rem] tracking-[0.06em] text-h26-text tabular-nums sm:text-[1.6rem] sm:tracking-[0.1em] md:text-[1.75rem]">
                 {device}
               </p>
-              <div className="flex flex-wrap gap-4 items-center mt-7">
-                <button
-                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
-                  onClick={() => setStep('digits')}
-                  type="button"
-                >
-                  I wrote it down
-                </button>
+              <div className="flex flex-wrap gap-4 justify-end items-center mt-7">
                 <button
                   className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
                   onClick={() => (onCancel ? onCancel() : setStep('closed'))}
                   type="button"
                 >
                   Cancel
+                </button>
+                <button
+                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
+                  onClick={() => setStep('digits')}
+                  type="button"
+                >
+                  I wrote it down
                 </button>
               </div>
             </div>
@@ -159,7 +159,14 @@ export function CustomizeVerificationNumber({
                 </div>
               </div>
 
-              <div className="flex flex-wrap gap-4 items-center mt-6">
+              <div className="flex flex-wrap gap-4 justify-end items-center mt-6">
+                <button
+                  className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
+                  onClick={() => setStep('write-down')}
+                  type="button"
+                >
+                  Back
+                </button>
                 <button
                   className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
                   disabled={!preview}
@@ -167,13 +174,6 @@ export function CustomizeVerificationNumber({
                   type="button"
                 >
                   Apply
-                </button>
-                <button
-                  className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
-                  onClick={() => setStep('write-down')}
-                  type="button"
-                >
-                  Back
                 </button>
               </div>
             </div>

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -18,7 +18,9 @@ export function CustomizeVerificationNumber({
   startOpen?: boolean
   state: State
 }) {
-  const [step, setStep] = useState<Step>(state.tracking_customized_at ? 'done' : startOpen ? 'write-down' : 'closed')
+  const [step, setStep] = useState<Step>(
+    state.previous_submissions?.length ? 'done' : startOpen ? 'write-down' : 'closed',
+  )
   const [digits, setDigits] = useState('')
   const [deviceSnapshot, setDeviceSnapshot] = useState(state.tracking || '')
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -1,5 +1,7 @@
 import { Check, PenLine } from 'lucide-react'
 import { Dispatch, useEffect, useRef, useState } from 'react'
+import { api } from 'src/api-helper'
+import { encodeReplacementPayload, signReplacement } from 'src/crypto/replacement-key'
 import { h26fonts } from 'src/homepage2026/fonts'
 
 import { strengthenTracking } from '../strengthen-tracking'
@@ -8,12 +10,16 @@ import { State } from '../vote-state'
 type Step = 'closed' | 'digits' | 'done' | 'write-down'
 
 export function CustomizeVerificationNumber({
+  auth,
   dispatch,
+  election_id,
   onCancel,
   startOpen = false,
   state,
 }: {
+  auth: string
   dispatch: Dispatch<Record<string, string>>
+  election_id: string
   onCancel?: () => void
   startOpen?: boolean
   state: State
@@ -23,11 +29,46 @@ export function CustomizeVerificationNumber({
   )
   const [digits, setDigits] = useState('')
   const [deviceSnapshot, setDeviceSnapshot] = useState(state.tracking || '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const pendingTracking = useRef<null | string>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (step === 'digits') inputRef.current?.focus()
   }, [step])
+
+  // After local re-encrypt, sign & POST the new ciphertext
+  useEffect(() => {
+    if (!pendingTracking.current || state.tracking !== pendingTracking.current) return
+    const privkey = state.replacement_privkey
+    if (!privkey || !Object.keys(state.encrypted).length) return
+
+    pendingTracking.current = null
+    ;(async () => {
+      try {
+        const message = encodeReplacementPayload({ auth, election_id, encrypted_vote: state.encrypted })
+        const signature = await signReplacement(privkey, message)
+        const response = await api('strengthened-vote', {
+          auth,
+          election_id,
+          encrypted_vote: state.encrypted,
+          signature,
+        })
+        if (response.status !== 200) {
+          const body = (await response.json()) as { error?: string }
+          setError(body.error || 'Failed to submit strengthened vote')
+          setSubmitting(false)
+          return
+        }
+        setStep('done')
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        setSubmitting(false)
+      }
+    })()
+  }, [auth, election_id, state.encrypted, state.replacement_privkey, state.tracking])
 
   if (!state.tracking) return null
 
@@ -40,13 +81,18 @@ export function CustomizeVerificationNumber({
     if (!state.tracking) return
     setDeviceSnapshot(state.tracking)
     setDigits('')
+    setError('')
     setStep('write-down')
   }
 
   const apply = () => {
-    if (!preview) return
+    if (!preview || submitting) return
+    if (!state.replacement_privkey) return setError('Missing replacement key on this device')
+
+    setError('')
+    setSubmitting(true)
+    pendingTracking.current = preview
     dispatch({ tracking: preview })
-    setStep('done')
   }
 
   return (
@@ -171,13 +217,14 @@ export function CustomizeVerificationNumber({
                 </button>
                 <button
                   className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
-                  disabled={!preview}
+                  disabled={!preview || submitting}
                   onClick={apply}
                   type="button"
                 >
-                  Apply
+                  {submitting ? 'Submitting…' : 'Apply'}
                 </button>
               </div>
+              {error && <p className="mt-3 mb-0 text-sm text-red-600">{error}</p>}
             </div>
           )}
         </div>

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -51,8 +51,11 @@ export function CustomizeVerificationNumber({
           onClick={open}
           type="button"
         >
-          <PenLine className="size-3.5 opacity-80 transition-transform duration-200 group-hover:-rotate-6" strokeWidth={1.75} />
-          Customize
+          <PenLine
+            className="size-3.5 opacity-80 transition-transform duration-200 group-hover:-rotate-6"
+            strokeWidth={1.75}
+          />
+          Customize your Verification Number
         </button>
       )}
 

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -1,0 +1,205 @@
+import { Check, PenLine } from 'lucide-react'
+import { Dispatch, useEffect, useRef, useState } from 'react'
+import { h26fonts } from 'src/homepage2026/fonts'
+
+import { strengthenTracking } from '../strengthen-tracking'
+import { State } from '../vote-state'
+
+type Step = 'closed' | 'digits' | 'done' | 'write-down'
+
+export function CustomizeVerificationNumber({
+  dispatch,
+  state,
+}: {
+  dispatch: Dispatch<Record<string, string>>
+  state: State
+}) {
+  const [step, setStep] = useState<Step>(state.tracking_customized_at ? 'done' : 'closed')
+  const [digits, setDigits] = useState(['', '', '', ''])
+  const [deviceSnapshot, setDeviceSnapshot] = useState(state.tracking || '')
+  const inputsRef = useRef<(HTMLInputElement | null)[]>([])
+
+  useEffect(() => {
+    if (step === 'digits') inputsRef.current[0]?.focus()
+  }, [step])
+
+  if (!state.tracking) return null
+
+  const digitString = digits.join('')
+  const preview = digitString.length === 4 ? strengthenTracking(deviceSnapshot, digitString) : null
+
+  const open = () => {
+    if (!state.tracking) return
+    setDeviceSnapshot(state.tracking)
+    setDigits(['', '', '', ''])
+    setStep('write-down')
+  }
+
+  const setDigit = (index: number, raw: string) => {
+    const char = raw.replace(/\D/g, '').slice(-1)
+    const next = [...digits]
+    next[index] = char
+    setDigits(next)
+    if (char && index < 3) inputsRef.current[index + 1]?.focus()
+  }
+
+  const onDigitKeyDown = (index: number, key: string) => {
+    if (key === 'Backspace' && !digits[index] && index > 0) inputsRef.current[index - 1]?.focus()
+  }
+
+  const onDigitPaste = (text: string) => {
+    const chars = text.replace(/\D/g, '').slice(0, 4).split('')
+    if (!chars.length) return
+    const next = ['', '', '', '']
+    chars.forEach((c, i) => (next[i] = c))
+    setDigits(next)
+    inputsRef.current[Math.min(chars.length, 3)]?.focus()
+  }
+
+  const apply = () => {
+    if (!preview) return
+    dispatch({ tracking: preview })
+    setStep('done')
+  }
+
+  return (
+    <div className={`mt-3 ${h26fonts}`}>
+      {step === 'closed' && (
+        <button
+          className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
+          onClick={open}
+          type="button"
+        >
+          <PenLine className="size-3.5 opacity-80 transition-transform duration-200 group-hover:-rotate-6" strokeWidth={1.75} />
+          Customize your Number
+        </button>
+      )}
+
+      {step === 'done' && (
+        <div className="inline-flex items-center gap-1.5 text-[0.78rem] text-h26-green animate-[fadeInUp_0.5s_ease-out_both]">
+          <Check className="size-3.5" strokeWidth={2} />
+          <span className="font-medium">Number customized</span>
+        </div>
+      )}
+
+      {(step === 'write-down' || step === 'digits') && (
+        <div
+          className={[
+            'mt-1 max-w-md rounded-[18px] p-5 md:p-6',
+            'bg-white/70 border border-white/80',
+            'shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06),inset_0_1px_0_0_rgba(255,255,255,0.5)]',
+            'backdrop-blur-md',
+            'animate-[fadeInUp_0.45s_ease-out_both]',
+          ].join(' ')}
+        >
+          <span className="font-mono26 text-[0.58rem] uppercase tracking-[0.2em] text-h26-green">Optional</span>
+          <h4 className="mt-1.5 mb-0 font-serif26 text-[1.05rem] font-normal tracking-tight text-h26-text">
+            Customize your Number
+          </h4>
+
+          {step === 'write-down' && (
+            <div className="mt-4">
+              <p className="m-0 text-[0.82rem] leading-[1.6] text-h26-textSecondary">
+                Write down your current verification number first — before entering any digits.
+              </p>
+              <p className="mt-4 mb-0 text-center font-mono26 text-[1.35rem] tracking-[0.12em] text-h26-text tabular-nums">
+                {deviceSnapshot.padStart(14, '0')}
+              </p>
+              <div className="mt-5 flex items-center gap-3">
+                <button
+                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-5 py-2.5 font-sans text-[0.82rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
+                  onClick={() => setStep('digits')}
+                  type="button"
+                >
+                  I wrote it down
+                </button>
+                <button
+                  className="border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
+                  onClick={() => setStep('closed')}
+                  type="button"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'digits' && (
+            <div className="mt-4">
+              <p className="m-0 text-[0.82rem] leading-[1.6] text-h26-textSecondary">
+                Add any 4 digits. They&apos;ll be combined into the last group of your number.
+              </p>
+
+              <div className="mt-5 grid gap-2.5 text-[0.8rem]">
+                <Row label="Device" value={deviceSnapshot.padStart(14, '0')} />
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-h26-muted shrink-0">You add</span>
+                  <div className="flex gap-1.5">
+                    {digits.map((d, i) => (
+                      <input
+                        className="h-10 w-9 rounded-lg border border-black/10 bg-white/90 text-center font-mono26 text-[1.05rem] text-h26-text outline-none transition-shadow focus:border-h26-green/40 focus:shadow-[0_0_0_3px_rgba(26,107,74,0.12)]"
+                        inputMode="numeric"
+                        key={i}
+                        maxLength={1}
+                        onChange={(e) => setDigit(i, e.target.value)}
+                        onKeyDown={(e) => onDigitKeyDown(i, e.key)}
+                        onPaste={(e) => {
+                          e.preventDefault()
+                          onDigitPaste(e.clipboardData.getData('text'))
+                        }}
+                        pattern="\d*"
+                        ref={(el) => {
+                          inputsRef.current[i] = el
+                        }}
+                        value={d}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <Row
+                  emphasize
+                  label="Result"
+                  value={preview?.padStart(14, '0') ?? '····-····-····'}
+                />
+              </div>
+
+              <div className="mt-5 flex items-center gap-3">
+                <button
+                  className="inline-flex items-center rounded-full border-0 bg-h26-green px-5 py-2.5 font-sans text-[0.82rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
+                  disabled={!preview}
+                  onClick={apply}
+                  type="button"
+                >
+                  Apply
+                </button>
+                <button
+                  className="border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
+                  onClick={() => setStep('write-down')}
+                  type="button"
+                >
+                  Back
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Row({ emphasize, label, value }: { emphasize?: boolean; label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-h26-muted shrink-0">{label}</span>
+      <span
+        className={[
+          'font-mono26 tracking-[0.08em] tabular-nums',
+          emphasize ? 'text-h26-text font-medium' : 'text-h26-textSecondary',
+        ].join(' ')}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -18,9 +18,7 @@ export function CustomizeVerificationNumber({
   startOpen?: boolean
   state: State
 }) {
-  const [step, setStep] = useState<Step>(
-    state.tracking_customized_at ? 'done' : startOpen ? 'write-down' : 'closed',
-  )
+  const [step, setStep] = useState<Step>(state.tracking_customized_at ? 'done' : startOpen ? 'write-down' : 'closed')
   const [digits, setDigits] = useState('')
   const [deviceSnapshot, setDeviceSnapshot] = useState(state.tracking || '')
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -129,7 +129,19 @@ export function CustomizeVerificationNumber({
           ].join(' ')}
         >
           <h4 className="mt-2 mb-0 font-serif26 text-[1.35rem] font-normal tracking-tight text-h26-text md:text-[1.5rem]">
-            Customize
+            Customize{' '}
+            <span className="font-sans text-[0.8rem] font-normal text-h26-muted">
+              (
+              <a
+                className="no-underline text-h26-muted hover:text-blue-600/50"
+                href="https://docs.siv.org/research-in-progress/strengthened-verif-nums"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                why?
+              </a>
+              )
+            </span>
           </h4>
 
           {step === 'write-down' && (

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -63,7 +63,7 @@ export function CustomizeVerificationNumber({
   }
 
   return (
-    <div className={`mt-3 ${h26fonts}`}>
+    <div className={`mt-0.5 ${h26fonts}`}>
       {step === 'closed' && (
         <button
           className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.78rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
@@ -71,14 +71,14 @@ export function CustomizeVerificationNumber({
           type="button"
         >
           <PenLine className="size-3.5 opacity-80 transition-transform duration-200 group-hover:-rotate-6" strokeWidth={1.75} />
-          Customize your Number
+          Customize
         </button>
       )}
 
       {step === 'done' && (
         <div className="inline-flex items-center gap-1.5 text-[0.78rem] text-h26-green animate-[fadeInUp_0.5s_ease-out_both]">
           <Check className="size-3.5" strokeWidth={2} />
-          <span className="font-medium">Number customized</span>
+          <span className="font-medium">Customized</span>
         </div>
       )}
 
@@ -94,7 +94,7 @@ export function CustomizeVerificationNumber({
         >
           <span className="font-mono26 text-[0.58rem] uppercase tracking-[0.2em] text-h26-green">Optional</span>
           <h4 className="mt-1.5 mb-0 font-serif26 text-[1.05rem] font-normal tracking-tight text-h26-text">
-            Customize your Number
+            Customize
           </h4>
 
           {step === 'write-down' && (

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -9,12 +9,18 @@ type Step = 'closed' | 'digits' | 'done' | 'write-down'
 
 export function CustomizeVerificationNumber({
   dispatch,
+  onCancel,
+  startOpen = false,
   state,
 }: {
   dispatch: Dispatch<Record<string, string>>
+  onCancel?: () => void
+  startOpen?: boolean
   state: State
 }) {
-  const [step, setStep] = useState<Step>(state.tracking_customized_at ? 'done' : 'closed')
+  const [step, setStep] = useState<Step>(
+    state.tracking_customized_at ? 'done' : startOpen ? 'write-down' : 'closed',
+  )
   const [digits, setDigits] = useState('')
   const [deviceSnapshot, setDeviceSnapshot] = useState(state.tracking || '')
   const inputRef = useRef<HTMLInputElement>(null)
@@ -45,7 +51,7 @@ export function CustomizeVerificationNumber({
 
   return (
     <div className={`mt-1 w-full min-w-0 max-w-full ${h26fonts}`}>
-      {step === 'closed' && (
+      {step === 'closed' && !startOpen && (
         <button
           className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.85rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
           onClick={open}
@@ -99,7 +105,7 @@ export function CustomizeVerificationNumber({
                 </button>
                 <button
                   className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
-                  onClick={() => setStep('closed')}
+                  onClick={() => (onCancel ? onCancel() : setStep('closed'))}
                   type="button"
                 >
                   Cancel

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -94,6 +94,19 @@ export function CustomizeVerificationNumber({
     setStep('write-down')
   }
 
+  const close = () => {
+    if (onCancel) return onCancel()
+    setStep(state.previous_submissions?.length ? 'done' : 'closed')
+  }
+
+  const [prefixA = '', prefixB = ''] = (state.tracking || '').split('-')
+  const trackingPrefix = `${prefixA}-${prefixB}-`
+  const previousLast4s = (state.previous_submissions || [])
+    .map((s) => s.tracking?.split('-')[2] || s.tracking?.slice(-4))
+    .filter((t): t is string => !!t)
+    .reverse()
+  const monoTracking = 'font-mono26 text-[0.95rem] tracking-[0.06em] tabular-nums'
+
   const apply = () => {
     if (!preview || submitting) return
     if (!state.replacement_privkey) return setError('Missing replacement key on this device')
@@ -132,6 +145,43 @@ export function CustomizeVerificationNumber({
               unlocks votes again.
             </p>
           )}
+
+          {/* Show current verif, and history of previous */}
+          <div className="mt-3 max-w-md">
+            <p className="m-0 text-[0.7rem] font-medium uppercase tracking-wide text-h26-muted">Current</p>
+            <p className={`mt-0.5 mb-0 ${monoTracking} text-h26-text`}>{state.tracking}</p>
+            {previousLast4s.length > 0 && (
+              <ul className="m-0 mt-0.5 list-none p-0">
+                {previousLast4s.map((last4, i) => (
+                  <li className={`flex items-baseline ${monoTracking} text-h26-muted`} key={`${last4}-${i}`}>
+                    <span className="relative">
+                      <span aria-hidden className="invisible select-none">
+                        {trackingPrefix}
+                      </span>
+                      {i === 0 && (
+                        <span className="absolute inset-0 flex items-center justify-end pr-1 font-sans text-[0.7rem] font-normal tracking-normal">
+                          was:
+                        </span>
+                      )}
+                    </span>
+                    {last4}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <button
+            className="group mt-3 inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.85rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
+            onClick={open}
+            type="button"
+          >
+            <PenLine
+              className="size-3.5 opacity-80 transition-transform duration-200 group-hover:-rotate-6"
+              strokeWidth={1.75}
+            />
+            Customize again
+          </button>
         </div>
       )}
 
@@ -172,7 +222,7 @@ export function CustomizeVerificationNumber({
               <div className="flex flex-wrap gap-4 justify-end items-center mt-7">
                 <button
                   className="border-0 bg-transparent p-0 font-sans text-[0.9rem] text-h26-muted cursor-pointer hover:text-h26-textSecondary"
-                  onClick={() => (onCancel ? onCancel() : setStep('closed'))}
+                  onClick={close}
                   type="button"
                 >
                   Cancel

--- a/src/vote/submitted/CustomizeVerificationNumber.tsx
+++ b/src/vote/submitted/CustomizeVerificationNumber.tsx
@@ -44,7 +44,7 @@ export function CustomizeVerificationNumber({
   }
 
   return (
-    <div className={`mt-1 ${h26fonts}`}>
+    <div className={`mt-1 w-full max-w-full min-w-0 ${h26fonts}`}>
       {step === 'closed' && (
         <button
           className="group inline-flex items-center gap-1.5 border-0 bg-transparent p-0 font-sans text-[0.85rem] text-h26-green cursor-pointer transition-colors duration-200 hover:text-h26-greenHover"
@@ -66,7 +66,7 @@ export function CustomizeVerificationNumber({
       {(step === 'write-down' || step === 'digits') && (
         <div
           className={[
-            'mt-1.5 max-w-lg rounded-[20px] p-6 md:p-7',
+            'mt-1.5 w-full max-w-lg rounded-[20px] p-4 sm:p-6 md:p-7',
             'bg-white/75 border border-white/80',
             'shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06),inset_0_1px_0_0_rgba(255,255,255,0.5)]',
             'backdrop-blur-md',
@@ -83,10 +83,10 @@ export function CustomizeVerificationNumber({
               <p className="m-0 text-[0.95rem] leading-[1.65] text-h26-textSecondary">
                 Write down your current verification number first — before entering any digits.
               </p>
-              <p className="mt-6 mb-0 text-center font-mono26 text-[1.6rem] tracking-[0.1em] text-h26-text tabular-nums md:text-[1.75rem]">
+              <p className="mt-6 mb-0 text-center font-mono26 text-[1.25rem] tracking-[0.06em] text-h26-text tabular-nums sm:text-[1.6rem] sm:tracking-[0.1em] md:text-[1.75rem]">
                 {device}
               </p>
-              <div className="mt-7 flex items-center gap-4">
+              <div className="mt-7 flex flex-wrap items-center gap-4">
                 <button
                   className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 hover:-translate-y-0.5 hover:bg-h26-greenHover hover:shadow-h26-cta-hover"
                   onClick={() => setStep('digits')}
@@ -106,29 +106,26 @@ export function CustomizeVerificationNumber({
           )}
 
           {step === 'digits' && (
-            <div className="mt-4">
+            <div className="mt-4 min-w-0">
               <p className="m-0 text-[0.95rem] leading-[1.65] text-h26-textSecondary">
                 Add any 4 digits. They&apos;ll be combined into the last group of your number.
               </p>
 
               {/* Prefix + last-group columns: hyphens stay in the mono string so they align with digits */}
-              <div className="mt-5 overflow-x-auto rounded-2xl border border-black/[0.06] bg-h26-bg/90 px-5 py-5">
-                <div
-                  className="grid w-max min-w-full items-center gap-x-0 gap-y-5"
-                  style={{ gridTemplateColumns: '6.75rem auto 6.5rem' }}
-                >
-                  <span className="text-[0.95rem] text-h26-muted">Device</span>
-                  <span className="font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-h26-text text-right">
+              <div className="mt-5 min-w-0 rounded-2xl border border-black/[0.06] bg-h26-bg/90 px-3 py-4 sm:px-5 sm:py-5">
+                <div className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_5.25rem] items-center gap-y-4 sm:grid-cols-[6.75rem_minmax(0,1fr)_6.5rem] sm:gap-y-5">
+                  <span className="pr-2 text-[0.85rem] text-h26-muted sm:pr-0 sm:text-[0.95rem]">Device</span>
+                  <span className="min-w-0 font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-h26-text text-right sm:text-[1.35rem] sm:tracking-[0.08em]">
                     {d1}-{d2}-
                   </span>
-                  <span className="font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-h26-text text-center">
+                  <span className="font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-h26-text text-center sm:text-[1.35rem] sm:tracking-[0.08em]">
                     {d3}
                   </span>
 
-                  <span className="text-[0.95rem] text-h26-muted">You add</span>
+                  <span className="pr-2 text-[0.85rem] text-h26-muted sm:pr-0 sm:text-[0.95rem]">You add</span>
                   <span />
                   <input
-                    className="box-border h-12 w-full rounded-lg border border-black/10 bg-white font-mono26 text-[1.35rem] tracking-[0.12em] text-center text-h26-text tabular-nums outline-none transition-shadow focus:border-h26-green/45 focus:shadow-[0_0_0_4px_rgba(26,107,74,0.12)]"
+                    className="box-border h-11 w-full rounded-lg border border-black/10 bg-white font-mono26 text-[1.05rem] tracking-[0.08em] text-center text-h26-text tabular-nums outline-none transition-shadow focus:border-h26-green/45 focus:shadow-[0_0_0_4px_rgba(26,107,74,0.12)] sm:h-12 sm:text-[1.35rem] sm:tracking-[0.12em]"
                     inputMode="numeric"
                     maxLength={4}
                     onChange={(e) => setDigits(e.target.value.replace(/\D/g, '').slice(0, 4))}
@@ -138,21 +135,21 @@ export function CustomizeVerificationNumber({
                     value={digits}
                   />
 
-                  <span className="text-[0.95rem] text-h26-muted">Result</span>
+                  <span className="pr-2 text-[0.85rem] text-h26-muted sm:pr-0 sm:text-[0.95rem]">Result</span>
                   <span
-                    className={`font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-right ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
+                    className={`min-w-0 font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-right sm:text-[1.35rem] sm:tracking-[0.08em] ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
                   >
                     {r1}-{r2}-
                   </span>
                   <span
-                    className={`font-mono26 text-[1.35rem] tracking-[0.08em] tabular-nums text-center ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
+                    className={`font-mono26 text-[1.05rem] tracking-[0.04em] tabular-nums text-center sm:text-[1.35rem] sm:tracking-[0.08em] ${preview ? 'font-medium text-h26-text' : 'text-h26-text'}`}
                   >
                     {r3}
                   </span>
                 </div>
               </div>
 
-              <div className="mt-6 flex items-center gap-4">
+              <div className="mt-6 flex flex-wrap items-center gap-4">
                 <button
                   className="inline-flex items-center rounded-full border-0 bg-h26-green px-6 py-3 font-sans text-[0.9rem] font-medium text-white cursor-pointer shadow-h26-cta transition-all duration-300 enabled:hover:-translate-y-0.5 enabled:hover:bg-h26-greenHover enabled:hover:shadow-h26-cta-hover disabled:cursor-not-allowed disabled:opacity-40"
                   disabled={!preview}

--- a/src/vote/submitted/SubmittedScreen.tsx
+++ b/src/vote/submitted/SubmittedScreen.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useEffect, useReducer } from 'react'
+import { Dispatch, useEffect, useReducer } from 'react'
 import { NoSsr } from 'src/_shared/NoSsr'
 
 import { MalwareCheck } from '../../malware-check/InitMalwareCheck'
 import { generateColumnNames } from '../generateColumnNames'
 import { State } from '../vote-state'
+import { CustomizeVerificationNumber } from './CustomizeVerificationNumber'
 import { DetailedEncryptionReceipt } from './DetailedEncryptionReceipt'
 import { EncryptedVote } from './EncryptedVote'
 import { InvalidatedVoteMessage } from './InvalidatedVoteMessage'
@@ -17,10 +18,12 @@ const disabledLinkToStatusPage = ['1764273267967', '1764288582801', '17786549054
 
 export function SubmittedScreen({
   auth,
+  dispatch,
   election_id,
   state,
 }: {
   auth: string
+  dispatch: Dispatch<Record<string, string>>
   election_id: string
   state: State & { submitted_at: Date }
 }): JSX.Element {
@@ -65,6 +68,7 @@ export function SubmittedScreen({
       </p>
 
       <UnlockedVote {...{ columns, state }} />
+      <CustomizeVerificationNumber {...{ dispatch, state }} />
 
       <p className="text-xs opacity-60">
         This secret <em>Verification #</em> is a random number, generated and encrypted on your own device.

--- a/src/vote/submitted/SubmittedScreen.tsx
+++ b/src/vote/submitted/SubmittedScreen.tsx
@@ -6,7 +6,6 @@ import { NoSsr } from 'src/_shared/NoSsr'
 import { MalwareCheck } from '../../malware-check/InitMalwareCheck'
 import { generateColumnNames } from '../generateColumnNames'
 import { State } from '../vote-state'
-import { CustomizeVerificationNumber } from './CustomizeVerificationNumber'
 import { DetailedEncryptionReceipt } from './DetailedEncryptionReceipt'
 import { EncryptedVote } from './EncryptedVote'
 import { InvalidatedVoteMessage } from './InvalidatedVoteMessage'
@@ -68,7 +67,6 @@ export function SubmittedScreen({
       </p>
 
       <UnlockedVote {...{ columns, state }} />
-      <CustomizeVerificationNumber {...{ dispatch, state }} />
 
       <p className="text-xs opacity-60">
         This secret <em>Verification #</em> is a random number, generated and encrypted on your own device.
@@ -76,7 +74,7 @@ export function SubmittedScreen({
         No one else can possibly know it.
       </p>
 
-      <MalwareCheck auth={malwareCheckAuth} {...{ election_id, state }} />
+      <MalwareCheck auth={malwareCheckAuth} {...{ dispatch, election_id, state }} />
 
       {/* Encryption */}
       <h3 className="mt-16">How your vote was submitted:</h3>

--- a/src/vote/submitted/UnlockedVote.tsx
+++ b/src/vote/submitted/UnlockedVote.tsx
@@ -3,7 +3,7 @@ import { unTruncateSelection } from 'src/status/un-truncate-selection'
 import { State } from '../vote-state'
 
 export const UnlockedVote = ({ columns, state }: { columns: string[]; state: State }) => (
-  <div className="pb-2 overflow-auto">
+  <div className="overflow-auto">
     <table className="w-auto border-collapse table-auto whitespace-nowrap">
       <thead>
         <tr>

--- a/src/vote/vote-state.test.ts
+++ b/src/vote/vote-state.test.ts
@@ -108,4 +108,16 @@ describe('vote-state reducer', () => {
     expect(String(submitted.submitted_at)).toBe('2026-01-01')
     expect(submitted.encrypted).toEqual(voted.encrypted)
   })
+
+  test('replacement keypair can be stored without re-encrypting', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
+    const withKeys = reducer(voted, {
+      replacement_privkey: 'a'.repeat(64),
+      replacement_pubkey: 'b'.repeat(64),
+    })
+
+    expect(withKeys.replacement_privkey).toBe('a'.repeat(64))
+    expect(withKeys.replacement_pubkey).toBe('b'.repeat(64))
+    expect(withKeys.encrypted).toEqual(voted.encrypted)
+  })
 })

--- a/src/vote/vote-state.test.ts
+++ b/src/vote/vote-state.test.ts
@@ -56,6 +56,8 @@ describe('vote-state reducer', () => {
       tracking: firstVerif,
     })
     expect(archived.replaced_at).toBeTruthy()
+    expect(archived).not.toHaveProperty('public_key')
+    expect(archived).not.toHaveProperty('previous_submissions')
     expect(second.randomizer.mayor).not.toBe(first.randomizer.mayor)
 
     // Third strengthen stacks; first archive stays intact

--- a/src/vote/vote-state.test.ts
+++ b/src/vote/vote-state.test.ts
@@ -34,9 +34,41 @@ describe('vote-state reducer', () => {
 
     expect(customized.tracking).toBe('1111-1111-2345')
     expect(customized.plaintext.mayor).toBe('Alice')
-    expect(customized.tracking_customized_at).toBeTruthy()
+    expect(customized.previous_submissions).toHaveLength(1)
     expect(decryptSelection(customized, 'mayor')).toBe('1111-1111-2345:Alice')
     expect(customized.encrypted.mayor).not.toEqual(voted.encrypted.mayor)
+  })
+
+  test('customizing archives prior crypto in previous_submissions', () => {
+    const firstVerif = '1111-1111-1111'
+    const first = reducer({ ...blank(), public_key: pub, tracking: firstVerif }, { mayor: 'Alice' })
+
+    const secondVerif = '1111-1111-2345'
+    const second = reducer(first, { tracking: secondVerif })
+
+    expect(second.previous_submissions).toHaveLength(1)
+    const [archived] = second.previous_submissions || []
+    expect(archived).toMatchObject({
+      encoded: first.encoded,
+      encrypted: first.encrypted,
+      plaintext: first.plaintext,
+      randomizer: first.randomizer,
+      tracking: firstVerif,
+    })
+    expect(archived.replaced_at).toBeTruthy()
+    expect(second.randomizer.mayor).not.toBe(first.randomizer.mayor)
+
+    // Third strengthen stacks; first archive stays intact
+    const third = reducer(second, { tracking: '1111-1111-9999' })
+    expect(third.previous_submissions).toHaveLength(2)
+    const [orig, next] = third.previous_submissions || []
+    expect(orig).toEqual(archived)
+    expect(next).toMatchObject({
+      encrypted: second.encrypted,
+      randomizer: second.randomizer,
+      tracking: secondVerif,
+    })
+    expect(next.replaced_at).toBeTruthy()
   })
 
   test('tracking customize is a no-op without plaintext or public key', () => {
@@ -53,7 +85,7 @@ describe('vote-state reducer', () => {
   test('same tracking does not take the customize path', () => {
     const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
     const again = reducer(voted, { tracking: '1111-1111-1111' })
-    expect(again.tracking_customized_at).toBeUndefined()
+    expect(again.previous_submissions).toBeUndefined()
     expect(decryptSelection(again, 'mayor')).toBe('1111-1111-1111:Alice')
   })
 

--- a/src/vote/vote-state.test.ts
+++ b/src/vote/vote-state.test.ts
@@ -120,4 +120,42 @@ describe('vote-state reducer', () => {
     expect(withKeys.replacement_pubkey).toBe('b'.repeat(64))
     expect(withKeys.encrypted).toEqual(voted.encrypted)
   })
+
+  test('customizing re-encrypts every contest under the new tracking', () => {
+    let state = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' }) // 1st contest
+    state = reducer(state, { prop: 'Yes' }) // add 2nd contest
+    const customized = reducer(state, { tracking: '1111-1111-2345' }) // customize tracking
+
+    // Both contests should be there, with updated tracking
+    expect(customized.plaintext).toEqual({ mayor: 'Alice', prop: 'Yes' })
+    expect(decryptSelection(customized, 'mayor')).toBe('1111-1111-2345:Alice')
+    expect(decryptSelection(customized, 'prop')).toBe('1111-1111-2345:Yes')
+  })
+
+  test('customizing archives submitted_at on the prior snapshot', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' }) // test selection
+    const submitted = reducer(voted, { submitted_at: '2026-01-01' }) // "submit vote"
+    const customized = reducer(submitted, { tracking: '1111-1111-2345' }) // customize tracking
+
+    // Expect the prior snapshot to be archived, with the submitted_at timestamp
+    expect(customized.previous_submissions?.[0]).toMatchObject({
+      submitted_at: '2026-01-01',
+      tracking: '1111-1111-1111',
+    })
+  })
+
+  test('tracking customize is a no-op without a prior tracking number', () => {
+    const withPlaintext = { ...blank(), plaintext: { mayor: 'Alice' }, public_key: pub }
+    expect(reducer(withPlaintext, { tracking: '1111-1111-2345' })).toEqual(withPlaintext)
+  })
+
+  test('changing a selection after customize encrypts under the current tracking', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
+    const customized = reducer(voted, { tracking: '1111-1111-2345' })
+    const changed = reducer(customized, { mayor: 'Bob' })
+
+    expect(changed.tracking).toBe('1111-1111-2345')
+    expect(decryptSelection(changed, 'mayor')).toBe('1111-1111-2345:Bob')
+    expect(changed.previous_submissions).toEqual(customized.previous_submissions)
+  })
 })

--- a/src/vote/vote-state.test.ts
+++ b/src/vote/vote-state.test.ts
@@ -71,7 +71,7 @@ describe('vote-state reducer', () => {
     const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
     const submitted = reducer(voted, { submitted_at: '2026-01-01' })
 
-    expect(submitted.submitted_at).toBe(new Date('2026-01-01'))
+    expect(String(submitted.submitted_at)).toBe('2026-01-01')
     expect(submitted.encrypted).toEqual(voted.encrypted)
   })
 })

--- a/src/vote/vote-state.test.ts
+++ b/src/vote/vote-state.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { pointToString, RP } from 'src/crypto/curve'
+import { decrypt } from 'src/crypto/decrypt'
+import { generate_key_pair } from 'src/crypto/generate-key-pair'
+
+import { reducer, State } from './vote-state'
+
+const { decryption_key, public_key } = generate_key_pair()
+const pub = public_key.toHex()
+
+const blank = (): State => ({ encoded: {}, encrypted: {}, plaintext: {}, randomizer: {} })
+
+function decryptSelection(state: State, key: string) {
+  const cipher = state.encrypted[key]
+  return pointToString(
+    decrypt(decryption_key, { encrypted: RP.fromHex(cipher.encrypted), lock: RP.fromHex(cipher.lock) }),
+  )
+}
+
+describe('vote-state reducer', () => {
+  test('encrypts selections as tracking:value and generates a tracking number', () => {
+    const state = reducer({ ...blank(), public_key: pub }, { mayor: 'Alice' })
+
+    expect(state.tracking).toMatch(/^\d{4}-\d{4}-\d{4}$/)
+    expect(state.plaintext.mayor).toBe('Alice')
+    expect(decryptSelection(state, 'mayor')).toBe(`${state.tracking}:Alice`)
+    expect(state.encoded.mayor).toBeTruthy()
+    expect(state.randomizer.mayor).toBeTruthy()
+  })
+
+  test('customizing tracking re-encrypts under the new number without changing selections', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
+    const customized = reducer(voted, { tracking: '1111-1111-2345' })
+
+    expect(customized.tracking).toBe('1111-1111-2345')
+    expect(customized.plaintext.mayor).toBe('Alice')
+    expect(customized.tracking_customized_at).toBeTruthy()
+    expect(decryptSelection(customized, 'mayor')).toBe('1111-1111-2345:Alice')
+    expect(customized.encrypted.mayor).not.toEqual(voted.encrypted.mayor)
+  })
+
+  test('tracking customize is a no-op without plaintext or public key', () => {
+    expect(reducer({ ...blank(), public_key: pub }, { tracking: '1111-1111-2345' })).toEqual({
+      ...blank(),
+      public_key: pub,
+    })
+    expect(reducer({ ...blank(), plaintext: { mayor: 'Alice' } }, { tracking: '1111-1111-2345' })).toEqual({
+      ...blank(),
+      plaintext: { mayor: 'Alice' },
+    })
+  })
+
+  test('same tracking does not take the customize path', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
+    const again = reducer(voted, { tracking: '1111-1111-1111' })
+    expect(again.tracking_customized_at).toBeUndefined()
+    expect(decryptSelection(again, 'mayor')).toBe('1111-1111-1111:Alice')
+  })
+
+  test('clearing a selection removes its encrypted fields', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
+    const cleared = reducer(voted, { mayor: '' })
+
+    expect(cleared.plaintext.mayor).toBeUndefined()
+    expect(cleared.encrypted.mayor).toBeUndefined()
+    expect(cleared.encoded.mayor).toBeUndefined()
+    expect(cleared.randomizer.mayor).toBeUndefined()
+  })
+
+  test('submitted_at updates without touching encryption', () => {
+    const voted = reducer({ ...blank(), public_key: pub, tracking: '1111-1111-1111' }, { mayor: 'Alice' })
+    const submitted = reducer(voted, { submitted_at: '2026-01-01' })
+
+    expect(submitted.submitted_at).toBe(new Date('2026-01-01'))
+    expect(submitted.encrypted).toEqual(voted.encrypted)
+  })
+})

--- a/src/vote/vote-state.ts
+++ b/src/vote/vote-state.ts
@@ -7,6 +7,16 @@ import { Item } from './storeElectionInfo'
 import { generateTrackingNum } from './tracking-num'
 import { useLocalStorageReducer } from './useLocalStorage'
 
+export type PreviousSubmission = {
+  encoded: Map
+  encrypted: Record<string, CipherStrings>
+  plaintext: Map
+  randomizer: Map
+  replaced_at: string
+  submitted_at?: Date | string
+  tracking: string
+}
+
 export type State = {
   auth_added_at?: string
   ballot_design?: Item[]
@@ -20,27 +30,41 @@ export type State = {
   last_modified_at?: Date
   link_auth?: string
   plaintext: Map
+  previous_submissions?: PreviousSubmission[]
   privacy_protectors_statements?: string
   public_key?: string
   randomizer: Map
   submission_confirmation?: string
   submitted_at?: Date
   tracking?: string
-  tracking_customized_at?: string
 }
 type Map = Record<string, string>
 
 /** Core state logic */
 export function reducer(prev: State, payload: Map) {
-  // Customize verification #: re-encrypt selections under the new tracking
+  // Customize verification #: re-encrypt under the new tracking, & archive prior
   if (payload.tracking && payload.tracking !== prev.tracking) {
-    if (!prev.public_key || !Object.keys(prev.plaintext || {}).length) return prev
+    if (!prev.public_key) return fail(prev, 'prev.public_key')
+    if (!prev.tracking) return fail(prev, 'prev.tracking')
+    if (!prev.plaintext || !Object.keys(prev.plaintext).length) return fail(prev, 'prev.plaintext')
+
     return {
       ...prev,
       ...encryptSelections(prev.plaintext, payload.tracking, prev.public_key),
       last_modified_at: new Date(),
+      previous_submissions: [
+        ...(prev.previous_submissions || []),
+        {
+          encoded: prev.encoded,
+          encrypted: prev.encrypted,
+          plaintext: prev.plaintext,
+          randomizer: prev.randomizer,
+          replaced_at: new Date().toISOString(),
+          tracking: prev.tracking,
+          ...(prev.submitted_at && { submitted_at: prev.submitted_at }),
+        },
+      ],
       tracking: payload.tracking,
-      tracking_customized_at: new Date().toISOString(),
     }
   }
 
@@ -94,6 +118,15 @@ function encryptSelections(plaintext: Map, tracking: string, public_key: string)
     return mapValues(cipher, String)
   })
   return { encoded, encrypted, randomizer }
+}
+
+function fail(prev: State, item: string) {
+  if (process.env.NODE_ENV !== 'test') {
+    const msg = `Error: ${item} missing`
+    console.error(msg, prev)
+    alert(msg)
+  }
+  return prev
 }
 
 const initState = {

--- a/src/vote/vote-state.ts
+++ b/src/vote/vote-state.ts
@@ -30,31 +30,8 @@ export type State = {
 }
 type Map = Record<string, string>
 
-function encryptSelections(plaintext: Map, tracking: string, public_key: string) {
-  // Initialize empty dicts for intermediary steps
-  const randomizer: Map = {}
-  const encoded: Map = {}
-
-  // For each key in plaintext
-  const encrypted = mapValues(plaintext, (value, key) => {
-    // Encode the string into an element of our Prime Order Group
-    encoded[key] = stringToPoint(`${tracking}:${value}`).toHex()
-
-    // Generate & store a randomizer
-    const random = random_bigint()
-    randomizer[key] = String(random)
-
-    // Encrypt the encoded value w/ its randomizer
-    const cipher = encrypt(RP.fromHex(public_key), random, RP.fromHex(encoded[key]))
-
-    // Store the encrypted cipher as strings
-    return mapValues(cipher, String)
-  })
-  return { encoded, encrypted, randomizer }
-}
-
 /** Core state logic */
-function reducer(prev: State, payload: Map) {
+export function reducer(prev: State, payload: Map) {
   // Customize verification #: re-encrypt selections under the new tracking
   if (payload.tracking && payload.tracking !== prev.tracking) {
     if (!prev.public_key || !Object.keys(prev.plaintext || {}).length) return prev
@@ -90,11 +67,33 @@ function reducer(prev: State, payload: Map) {
   if (Object.keys(newState.plaintext) && !prev.public_key) return prev
 
   // Generate Verification number if needed
-
   if (!newState.tracking) newState.tracking = generateTrackingNum()
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return merge(newState, encryptSelections(newState.plaintext, newState.tracking, prev.public_key!))
+}
+
+function encryptSelections(plaintext: Map, tracking: string, public_key: string) {
+  // Initialize empty dicts for intermediary steps
+  const randomizer: Map = {}
+  const encoded: Map = {}
+
+  // For each key in plaintext
+  const encrypted = mapValues(plaintext, (value, key) => {
+    // Encode the string into an element of our Prime Order Group
+    encoded[key] = stringToPoint(`${tracking}:${value}`).toHex()
+
+    // Generate & store a randomizer
+    const random = random_bigint()
+    randomizer[key] = String(random)
+
+    // Encrypt the encoded value w/ its randomizer
+    const cipher = encrypt(RP.fromHex(public_key), random, RP.fromHex(encoded[key]))
+
+    // Store the encrypted cipher as strings
+    return mapValues(cipher, String)
+  })
+  return { encoded, encrypted, randomizer }
 }
 
 const initState = {

--- a/src/vote/vote-state.ts
+++ b/src/vote/vote-state.ts
@@ -20,6 +20,8 @@ export type State = VoteData & {
   previous_submissions?: (VoteData & { replaced_at: string })[]
   privacy_protectors_statements?: string
   public_key?: string
+  replacement_privkey?: string
+  replacement_pubkey?: string
   submission_confirmation?: string
 }
 
@@ -35,7 +37,8 @@ type VoteData = {
 
 /** Core state logic */
 export function reducer(prev: State, payload: Map) {
-  // Customize verification #: re-encrypt under the new tracking, & archive prior
+  // Special handler for customizing verification number.
+  // Re-encrypt under the new tracking, & archive prior
   if (payload.tracking && payload.tracking !== prev.tracking) {
     if (!prev.public_key) return fail(prev, 'prev.public_key')
     if (!prev.tracking) return fail(prev, 'prev.tracking')
@@ -58,7 +61,14 @@ export function reducer(prev: State, payload: Map) {
 
   // Special handler for other state updates
   // that don't require encryption
-  if (payload.ballot_design || payload.submitted_at || payload.esigned_at || payload.link_auth) {
+  if (
+    payload.ballot_design ||
+    payload.submitted_at ||
+    payload.esigned_at ||
+    payload.link_auth ||
+    payload.replacement_privkey ||
+    payload.replacement_pubkey
+  ) {
     return { ...prev, ...payload }
   }
 

--- a/src/vote/vote-state.ts
+++ b/src/vote/vote-state.ts
@@ -26,11 +26,47 @@ export type State = {
   submission_confirmation?: string
   submitted_at?: Date
   tracking?: string
+  tracking_customized_at?: string
 }
 type Map = Record<string, string>
 
+function encryptSelections(plaintext: Map, tracking: string, public_key: string) {
+  // Initialize empty dicts for intermediary steps
+  const randomizer: Map = {}
+  const encoded: Map = {}
+
+  // For each key in plaintext
+  const encrypted = mapValues(plaintext, (value, key) => {
+    // Encode the string into an element of our Prime Order Group
+    encoded[key] = stringToPoint(`${tracking}:${value}`).toHex()
+
+    // Generate & store a randomizer
+    const random = random_bigint()
+    randomizer[key] = String(random)
+
+    // Encrypt the encoded value w/ its randomizer
+    const cipher = encrypt(RP.fromHex(public_key), random, RP.fromHex(encoded[key]))
+
+    // Store the encrypted cipher as strings
+    return mapValues(cipher, String)
+  })
+  return { encoded, encrypted, randomizer }
+}
+
 /** Core state logic */
 function reducer(prev: State, payload: Map) {
+  // Customize verification #: re-encrypt selections under the new tracking
+  if (payload.tracking && payload.tracking !== prev.tracking) {
+    if (!prev.public_key || !Object.keys(prev.plaintext || {}).length) return prev
+    return {
+      ...prev,
+      ...encryptSelections(prev.plaintext, payload.tracking, prev.public_key),
+      last_modified_at: new Date(),
+      tracking: payload.tracking,
+      tracking_customized_at: new Date().toISOString(),
+    }
+  }
+
   // Special handler for other state updates
   // that don't require encryption
   if (payload.ballot_design || payload.submitted_at || payload.esigned_at || payload.link_auth) {
@@ -54,30 +90,11 @@ function reducer(prev: State, payload: Map) {
   if (Object.keys(newState.plaintext) && !prev.public_key) return prev
 
   // Generate Verification number if needed
-  if (!prev.tracking) newState.tracking = generateTrackingNum()
 
-  // Initialize empty dicts for intermediary steps
-  const randomizer: Map = {}
-  const encoded: Map = {}
+  if (!newState.tracking) newState.tracking = generateTrackingNum()
 
-  // For each key in plaintext
-  const encrypted = mapValues(newState.plaintext, (value, key) => {
-    // Encode the string into an element of our Prime Order Group
-    encoded[key] = stringToPoint(`${newState.tracking}:${value}`).toHex()
-
-    // Generate & store a randomizer
-    const random = random_bigint()
-    randomizer[key] = String(random)
-
-    // Encrypt the encoded value w/ its randomizer
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const cipher = encrypt(RP.fromHex(prev.public_key!), random, RP.fromHex(encoded[key]))
-
-    // Store the encrypted cipher as strings
-    return mapValues(cipher, String)
-  })
-
-  return merge(newState, { encoded, encrypted, randomizer })
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return merge(newState, encryptSelections(newState.plaintext, newState.tracking, prev.public_key!))
 }
 
 const initState = {

--- a/src/vote/vote-state.ts
+++ b/src/vote/vote-state.ts
@@ -1,4 +1,4 @@
-import { mapValues, merge } from 'lodash-es'
+import { mapValues, merge, pick } from 'lodash-es'
 import { random_bigint, RP, stringToPoint } from 'src/crypto/curve'
 import { CipherStrings } from 'src/crypto/stringify-shuffle'
 
@@ -7,38 +7,31 @@ import { Item } from './storeElectionInfo'
 import { generateTrackingNum } from './tracking-num'
 import { useLocalStorageReducer } from './useLocalStorage'
 
-export type PreviousSubmission = {
-  encoded: Map
-  encrypted: Record<string, CipherStrings>
-  plaintext: Map
-  randomizer: Map
-  replaced_at: string
-  submitted_at?: Date | string
-  tracking: string
-}
-
-export type State = {
+export type State = VoteData & {
   auth_added_at?: string
   ballot_design?: Item[]
   ballot_design_finalized?: boolean
   custom_invitation_text?: string
   election_manager?: string
   election_title?: string
-  encoded: Map
-  encrypted: Record<string, CipherStrings>
   esignature_requested?: boolean
   last_modified_at?: Date
   link_auth?: string
-  plaintext: Map
-  previous_submissions?: PreviousSubmission[]
+  previous_submissions?: (VoteData & { replaced_at: string })[]
   privacy_protectors_statements?: string
   public_key?: string
-  randomizer: Map
   submission_confirmation?: string
+}
+
+type Map = Record<string, string>
+type VoteData = {
+  encoded: Map
+  encrypted: Record<string, CipherStrings>
+  plaintext: Map
+  randomizer: Map
   submitted_at?: Date
   tracking?: string
 }
-type Map = Record<string, string>
 
 /** Core state logic */
 export function reducer(prev: State, payload: Map) {
@@ -55,13 +48,8 @@ export function reducer(prev: State, payload: Map) {
       previous_submissions: [
         ...(prev.previous_submissions || []),
         {
-          encoded: prev.encoded,
-          encrypted: prev.encrypted,
-          plaintext: prev.plaintext,
-          randomizer: prev.randomizer,
+          ...pick(prev, ['encoded', 'encrypted', 'plaintext', 'randomizer', 'submitted_at', 'tracking']),
           replaced_at: new Date().toISOString(),
-          tracking: prev.tracking,
-          ...(prev.submitted_at && { submitted_at: prev.submitted_at }),
         },
       ],
       tracking: payload.tracking,


### PR DESCRIPTION
Beginning to implement the design described here: https://docs.siv.org/research-in-progress/strengthened-verif-nums

## UI:
- [x] After initial submission, voter can opt-in to "customize" their Verification Number.
_The option to Customize is nested under `[+] Verify your vote wasn't changed by malware` (collapsed by default)_

<img width="952" height="513" alt="image" src="https://github.com/user-attachments/assets/4bf03960-f959-4344-9b12-37ae1b398429" />

- [x] Instructions encouraging voters to first write-down-on-paper their device-assigned initial Verif Number.
  - Acknowledging that client-side malware **_can_** easily strip this out. Still, including it does still adds non-zero value to help create general awareness of how the feature is *supposed* to work. (As long as we aren't entirely depending upon it.)

<img width="936" height="477" alt="image" src="https://github.com/user-attachments/assets/36a7e196-f850-4233-9517-2ece3834f851" />

- [x] Then they are asked to input their 4 digits to strengthen.

<img width="956" height="612" alt="image" src="https://github.com/user-attachments/assets/fd6ea285-501e-431e-bdd0-03d2b173455e" />

- [x] Then they are shown their new, Strengthened Verification Number (device entropy + user-supplied entropy).

<img width="966" height="389" alt="image" src="https://github.com/user-attachments/assets/602c1cd7-860f-4c05-b05f-d0f5ff8a9dce" />

- [x] Voters can strengthen more than once, and see past history

<img width="573" height="296" alt="image" src="https://github.com/user-attachments/assets/654e93ec-192b-492e-b1d5-9d3428456169" />

- [x] Admin UI shows if there have been new strengthenings since the votes were previously unlocked. _(For this v1, it does not show who strengthened or not.)_

<img width="572" height="184" alt="image" src="https://github.com/user-attachments/assets/f9531533-a039-4c38-a3ed-88df74451d24" />



## Backend:
Cleanly replaces the voter's initial submission.
- [x] Voter device locally creates "replacement" keypair, pubkey submitted with orig vote,  to auth future submissions. (See [design notes below](https://github.com/siv-org/siv/pull/314#issuecomment-5153277300) for considerations)
- [x] **`POST /strengthened-vote`** — accepts and verifies the signed replace
- [x] **Auditability** — prior ciphertext archived in `previous_submissions`
- [x] **`GET /cache-accepted`** — `invalidateCachedVote()` keeps the packed cache current

## Client-side Storage
- [x] LocalStorage keeps the original submissions' randomizers etc in a `previousSubmissions[]` archive.

## Unit tests
- [x] Added new unit tests around `vote-state.ts`, since this touches that. They seem like a relatively good start for testing the `reducer()` paths.
- [x] Manually ran the new tests on the *previous* version of `vote-state.ts`, before it was refactored in this PR's initial commit. To confirm the core behavior there didn't change.
- [x] The new function `strengthen-tracking.ts` also has some reasonable unit tests, to confirm the adding behavior is working as intended.
- [x] Added [new helper `withApiErrorLogs()`](https://github.com/siv-org/siv/pull/314/changes/762701115d75961c15d7b3c48ac39d59838d462d) to `POST /submit-vote` to improve error logging for 4xx bodies. Very easy to add to other endpoints later too, if we like it.
- [x] Added new integration tests for /cache-accepted correctly handling the updated submissions.

## ZK Proof of Strengthened Verif Number:
- This is out-of-scope for this initial version of the feature. We can test the UI / voter-UX without it.

