### PR TITLE
safeOrigin: email and localhost links from VERCEL_URL

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,11 +72,13 @@ function sivPlugin() {
           return {
             MemberExpression(node) {
               const prop = node.computed ? node.property.value : node.property.name
-              if (prop !== 'host') return
+              if (!['host', 'origin'].includes(prop)) return
               const obj = node.object.type === 'ChainExpression' ? node.object.expression : node.object
-              if (obj.type !== 'MemberExpression' || obj.property.name !== 'headers') return
+              const fromReqHeaders = obj.type === 'MemberExpression' && obj.property.name === 'headers'
+              const fromHeadersVar = obj.type === 'Identifier' && obj.name === 'headers'
+              if (!fromReqHeaders && !fromHeadersVar) return
               context.report({
-                message: "Don't trust req.headers.host, can be spoofed. Prefer safeOrigin(req)",
+                message: "Don't trust spoofable req.headers.host/origin. Prefer safeOrigin(req)",
                 node,
               })
             },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,12 +20,13 @@ const commonConfig = {
     },
     sourceType: 'module',
   },
-  plugins: { react: reactPlugin },
+  plugins: { react: reactPlugin, siv: sivPlugin() },
   rules: {
     ...reactPlugin.configs.flat.recommended.rules,
     'no-restricted-syntax': ['error', ...secretsMatchSelectors()],
     'no-unreachable': 'warn',
     'react/no-unknown-property': [2, { ignore: ['jsx', 'global'] }], // styled-jsx
+    'siv/no-req-headers-host': 'warn',
   },
   settings: { react: { version: 'detect' } },
 }
@@ -61,4 +62,28 @@ function secretsMatchSelectors() {
     `${eq}[right.type!='Literal'] > MemberExpression.left[property.name='auth']`,
     `${eq}[left.type!='Literal'] > MemberExpression.right[property.name='auth']`,
   ].map((selector) => ({ message: "Don't directly compare secret fields with ===/!==. Use secretsMatch()", selector }))
+}
+
+function sivPlugin() {
+  return {
+    rules: {
+      'no-req-headers-host': {
+        create(context) {
+          return {
+            MemberExpression(node) {
+              const prop = node.computed ? node.property.value : node.property.name
+              if (prop !== 'host') return
+              const obj = node.object.type === 'ChainExpression' ? node.object.expression : node.object
+              if (obj.type !== 'MemberExpression' || obj.property.name !== 'headers') return
+              context.report({
+                message: "Don't trust req.headers.host, can be spoofed. Prefer safeOrigin(req)",
+                node,
+              })
+            },
+          }
+        },
+        meta: { docs: {}, schema: [], type: 'problem' },
+      },
+    },
+  }
 }

--- a/pages/api/11-chooses/prep/reset-test-votes.ts
+++ b/pages/api/11-chooses/prep/reset-test-votes.ts
@@ -1,5 +1,6 @@
 import { firebase } from 'api/_services'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { election_ids_for_11chooses } from 'src/vote/auth/11choosesAuth/CustomAuthFlow'
 
 const { RECENT_ELECTIONS_PASSWORD } = process.env
@@ -9,7 +10,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (!RECENT_ELECTIONS_PASSWORD) return res.status(401).send('Server missing process.env.RECENT_ELECTIONS_PASSWORD')
   if (req.query.pass !== RECENT_ELECTIONS_PASSWORD) return res.status(401).send('Unauthorized')
 
-  if (!req.headers.host?.startsWith('localhost:300')) return res.status(405).json({ error: 'For localhost only' })
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string' || !origin.startsWith('http://localhost:300'))
+    return res.status(405).json({ error: 'For localhost only' })
 
   const { election_id } = req.query
   if (typeof election_id !== 'string') return res.status(400).json({ error: 'election_id is required' })

--- a/pages/api/11-chooses/prep/upload-voters-test.ts
+++ b/pages/api/11-chooses/prep/upload-voters-test.ts
@@ -1,6 +1,7 @@
 import { firebase } from 'api/_services'
 import { firestore } from 'firebase-admin'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { election_ids_for_11chooses } from 'src/vote/auth/11choosesAuth/CustomAuthFlow'
 
 /* For each record (~62k): {
@@ -62,7 +63,9 @@ export const voterFileToUploadFormat = (v: (typeof sample_voters)[number], index
 // console.log(sample_voters.map(voterFileToUploadFormat))
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!req.headers.host?.startsWith('localhost:300')) return res.status(405).json({ error: 'For localhost only' })
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string' || !origin.startsWith('http://localhost:300'))
+    return res.status(405).json({ error: 'For localhost only' })
 
   const { election_id } = req.query
   if (typeof election_id !== 'string') return res.status(400).json({ error: 'election_id is required' })

--- a/pages/api/admin-create-account.ts
+++ b/pages/api/admin-create-account.ts
@@ -1,5 +1,6 @@
 import { validate as validateEmail } from 'email-validator'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 
 import { firebase, pushover, sendEmail } from './_services'
 import { generateEmailLoginCode } from './admin-login'
@@ -64,6 +65,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       .catch(() => {}),
   ])
 
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
+
   const blank = (s: string) => (s ? s : '—')
   // Send message w/ Approval Link
   const message = `New SIV Admin Application
@@ -83,9 +87,9 @@ Election date: ${blank(election_date)}
 Election number of voters: ${blank(election_num_voters)}`
 }
 
-Link to approve: ${req.headers.origin}/approve-admin?id=${doc_id}
+Link to approve: ${origin}/approve-admin?id=${doc_id}
 
-Approve & skip email verification: ${req.headers.origin}/approve-admin?id=${doc_id}&skip_init_email_validation=true
+Approve & skip email verification: ${origin}/approve-admin?id=${doc_id}&skip_init_email_validation=true
 (The device that submitted the admin application will be logged in)`
 
   await Promise.all([

--- a/pages/api/admin-login.ts
+++ b/pages/api/admin-login.ts
@@ -1,6 +1,7 @@
 import { validate } from 'email-validator'
 import { firestore } from 'firebase-admin'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { pick_random_bigint } from 'src/crypto/pick-random-bigint'
 
 import { firebase, sendEmail } from './_services'
@@ -33,7 +34,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const login_code = generateEmailLoginCode()
   adminDoc.collection('logins').doc(new Date().toISOString()).set({ created_at: new Date(), login_code })
 
-  const link = `${req.headers.origin}/admin?email=${email}&code=${login_code}`
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
+
+  const link = `${origin}/admin?email=${email}&code=${login_code}`
   await sendEmail({
     from: 'SIV',
     recipient: email,

--- a/pages/api/election/[election_id]/admin/add-trustees.ts
+++ b/pages/api/election/[election_id]/admin/add-trustees.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { Trustee } from 'src/admin/PrivacyPage/SetPrivacyProtectors'
 import { generateAuthToken } from 'src/crypto/generate-auth-tokens'
 import { generate_key_pair } from 'src/crypto/generate-key-pair'
@@ -27,6 +28,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
   if (!jwt.valid) return
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   const { trustees } = req.body as { trustees: Trustee[] }
   const { election_manager, election_title } = jwt
@@ -88,7 +92,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       trustees.map(({ email, name }: Trustee, index: number) => {
         if (email === ADMIN_EMAIL) return
 
-        const link = `${req.headers.origin}/election/${election_id}/observer?auth=${auth_tokens[index]}`
+        const link = `${origin}/election/${election_id}/observer?auth=${auth_tokens[index]}`
 
         return sendTrusteeInvite({ election_id, election_manager, election_title, email, link, name })
       }),

--- a/pages/api/election/[election_id]/admin/edit-trustee-email.ts
+++ b/pages/api/election/[election_id]/admin/edit-trustee-email.ts
@@ -1,5 +1,6 @@
 import { validate as validateEmail } from 'email-validator'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { generateAuthToken } from 'src/crypto/generate-auth-tokens'
 
 import { firebase } from '../../../_services'
@@ -15,6 +16,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
   if (!jwt.valid) return
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   const { election_manager, election_title } = jwt
 
@@ -56,7 +60,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   ])
 
   // Send trustee invite email to new_email
-  const link = `${req.headers.origin}/election/${election_id}/observer?auth=${new_auth_token}`
+  const link = `${origin}/election/${election_id}/observer?auth=${new_auth_token}`
   await sendTrusteeInvite({
     election_id,
     election_manager,

--- a/pages/api/election/[election_id]/admin/invite-voters.ts
+++ b/pages/api/election/[election_id]/admin/invite-voters.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import throat from 'throat'
 
 import { firebase } from '../../../_services'
@@ -14,6 +15,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
   if (!jwt.valid) return
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   // Lookup election title and custom invitation text
   const electionDoc = firebase.firestore().collection('elections').doc(election_id)
@@ -36,7 +40,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         if (!voter.exists) return { error: `Can't find voter ${email}` }
         const { auth_token, invite_queued } = { ...voter.data() } as { auth_token: string; invite_queued?: QueueLog[] }
 
-        const link = `${req.headers.origin}/election/${election_id}/vote?auth=${auth_token}`
+        const link = `${origin}/election/${election_id}/vote?auth=${auth_token}`
         // const link = `https://siv.org/election/${election_id}/vote?auth=${auth_token}`
 
         return send_invitation_email({

--- a/pages/api/election/[election_id]/admin/notify-unlocked.ts
+++ b/pages/api/election/[election_id]/admin/notify-unlocked.ts
@@ -1,6 +1,7 @@
 import bluebird from 'bluebird'
 import { validate } from 'email-validator'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 
 import { firebase, sendEmail } from '../../../_services'
 import { checkJwtOwnsElection } from '../../../validate-admin-jwt'
@@ -24,6 +25,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
   if (!jwt.valid) return
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   // Is election_id in DB?
   const electionDoc = await loadElection
@@ -70,7 +74,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           text: `<h2 style="margin: 0">Election Results Posted</h2>
           ${voters.length} vote${voters.length !== 1 ? 's' : ''} for "${election_title}" ha${
             voters.length !== 1 ? 've' : 's'
-          } been unlocked: ${req.headers.origin}/election/${election_id}
+          } been unlocked: ${origin}/election/${election_id}
           `,
         }).then(() => {
           // Wait a second after sending to not overload Mailgun

--- a/pages/api/election/[election_id]/admin/send-test-invitation.ts
+++ b/pages/api/election/[election_id]/admin/send-test-invitation.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 
 import { firebase } from '../../../_services'
 import { buildSubject, send_invitation_email } from '../../../invite-voters'
@@ -10,6 +11,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   // Confirm they're a valid admin that created this election
   const jwt = await checkJwtOwnsElection(req, res, election_id)
   if (!jwt.valid) return
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   try {
     // Lookup election title and custom invitation text
@@ -28,7 +32,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Create a test auth token (10 characters, hex)
     const testAuthToken = '1a2b3c4d5e'
-    const testLink = `${req.headers.origin}/election/${election_id}/vote?auth=${testAuthToken}`
+    const testLink = `${origin}/election/${election_id}/vote?auth=${testAuthToken}`
 
     // Send test invitation email to the admin
     const result = await send_invitation_email({

--- a/pages/api/election/[election_id]/admin/unlock.ts
+++ b/pages/api/election/[election_id]/admin/unlock.ts
@@ -118,7 +118,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     elapsed('fastShuffle')
 
     // Decrypt votes
-    const origin = safeOrigin(req.headers.host)
+    const origin = safeOrigin(req)
     if (typeof origin !== 'string') return res.status(500).json(origin)
     const decrypted_and_split = await bluebird.props(
       mapValues(shuffled, async (list) => {

--- a/pages/api/election/[election_id]/submit-link-auth-info.ts
+++ b/pages/api/election/[election_id]/submit-link-auth-info.ts
@@ -4,6 +4,7 @@ import { pusher } from 'api/pusher'
 import { validate as validateEmail } from 'email-validator'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { escapeHtml } from 'src/_shared/escapeHtml'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { optionalEmail } from 'src/vote/auth/VoterAuthInfoForm'
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
@@ -26,6 +27,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const election = (await loadElection).data() || {}
   if (!election.voter_applications_allowed)
     return res.status(401).json({ error: 'This election disabled Voter Applications' })
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   // Server assigns them a Email-Verification code
   const verification_code = generateEmailLoginCode()
@@ -68,13 +72,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       If this was you, please confirm:
 
       ${button(
-        `${req.headers.origin}/verify_registration?email=${encodeURIComponent(email)}&code=${verification_code}&election_id=${election_id}&link_auth=${link_auth}`,
+        `${origin}/verify_registration?email=${encodeURIComponent(email)}&code=${verification_code}&election_id=${election_id}&link_auth=${link_auth}`,
         'Confirm this was me',
       )}
 
       <em style="font-size:11px; opacity: 0.6;">
       Didn't submit this vote? <a href="${
-        req.headers.origin
+        origin
       }/verify_registration?code=${verification_code}&election_id=${election_id}&link_auth=${link_auth}&invalid=true">Mark it as invalid.</a></em>`,
       }),
 

--- a/pages/api/load.ts
+++ b/pages/api/load.ts
@@ -23,6 +23,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { headers } = req
   const { hash, height, width } = req.body
 
+  // eslint-disable-next-line siv/no-req-headers-host -- analytics
   const domain = headers.origin || ''
   const page_url = headers.referer?.slice(domain.length)
   const ip = headers['x-forwarded-for']

--- a/pages/api/sms/otp-result.ts
+++ b/pages/api/sms/otp-result.ts
@@ -37,6 +37,7 @@ const isAllowedDomain = (origin: string) =>
 
 function setCORSForAllowedDomains(fn: NextApiHandler) {
   return async (req: NextApiRequest, res: NextApiResponse) => {
+    // eslint-disable-next-line siv/no-req-headers-host -- CORS: this is the caller's Origin, not a URL we build
     const origin = req.headers.origin
 
     // Block non-allowed domains

--- a/pages/api/submit-vote.ts
+++ b/pages/api/submit-vote.ts
@@ -1,6 +1,7 @@
 import { validate as validateEmail } from 'email-validator'
 import { firestore } from 'firebase-admin'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 import { generateAuthToken } from 'src/crypto/generate-auth-tokens'
 import { is64HexChars } from 'src/crypto/replacement-key'
 import { CipherStrings } from 'src/crypto/stringify-shuffle'
@@ -22,6 +23,9 @@ export default withApiErrorLogs(async (req: NextApiRequest, res: NextApiResponse
 
   if (!is64HexChars(replacement_pubkey))
     return res.status(400).json({ error: 'Missing or malformed replacement_pubkey' })
+
+  const origin = safeOrigin(req)
+  if (typeof origin !== 'string') return res.status(500).json(origin)
 
   // return res.status(200).json({ auth, election_id, encrypted_vote })
 
@@ -78,9 +82,7 @@ export default withApiErrorLogs(async (req: NextApiRequest, res: NextApiResponse
     ])
 
     // Link to the auth url, particularly for AirgappedVoters
-    const host = req.headers.host
-    const protocol = host?.startsWith('localhost') ? 'http://' : 'https://'
-    const visit_to_add_auth = `${protocol}${host}/election/${election_id}/auth?link=${link_auth}`
+    const visit_to_add_auth = `${origin}/election/${election_id}/auth?link=${link_auth}`
 
     return res.status(200).json({
       link_auth,
@@ -134,7 +136,7 @@ export default withApiErrorLogs(async (req: NextApiRequest, res: NextApiResponse
 
   // Skip if email isn't valid (e.g. used QR invitations)
   if (validateEmail(email)) {
-    const link = `${req.headers.origin || req.headers.host}/election/${election_id}`
+    const link = `${origin}/election/${election_id}`
     const { election_manager } = (await election).data() as {
       election_manager?: string
       election_title?: string

--- a/pages/api/suspend-admin.ts
+++ b/pages/api/suspend-admin.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import { safeOrigin } from 'src/_shared/safeOrigin'
 
 import { firebase } from './_services'
 
@@ -6,7 +7,8 @@ const suspensionEnabled = false
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   // This endpoint is not meant to be accessible anywhere other than locally
-  if (!suspensionEnabled || req.headers.host !== 'localhost:3000') return res.status(404).send('Not found')
+  const origin = safeOrigin(req)
+  if (!suspensionEnabled || origin !== 'http://localhost:3000') return res.status(404).send('Not found')
 
   // Will need to URL encode these fields, using a tool like https://www.urlencoder.io
   const { id, suspended_for } = req.query

--- a/pages/api/validate-admin-jwt.ts
+++ b/pages/api/validate-admin-jwt.ts
@@ -42,6 +42,7 @@ export async function checkJwt(
     console.error('caught error verifying jwt', e)
     await pushover(
       'Invalid JWT signature',
+      // eslint-disable-next-line siv/no-req-headers-host -- logging the caller
       `${req.headers.origin} ${req.url}\n${JSON.stringify(jwt.decode(cookie))}\n${cookie}`,
     )
     return { res: res.status(401).send({ error: 'Invalid JWT' }), valid: false }

--- a/src/_shared/safeOrigin.test.ts
+++ b/src/_shared/safeOrigin.test.ts
@@ -1,6 +1,10 @@
+import type { NextApiRequest } from 'next'
+
 import { expect, test } from 'bun:test'
 
 import { safeOrigin } from './safeOrigin'
+
+const req = (host?: string) => ({ headers: { host } } as NextApiRequest)
 
 test('uses VERCEL_URL when the host looks like ours', () => {
   expect(safeOrigin(undefined, { VERCEL_URL: 'siv-git-main-sivteam.vercel.app' })).toBe(
@@ -22,13 +26,13 @@ test('refuses unexpected VERCEL_URL', () => {
 })
 
 test('fallback to localhost for local dev', () => {
-  expect(safeOrigin('localhost:3001', { PORT: '3001' })).toBe('http://localhost:3001')
-  expect(safeOrigin('localhost:3000', {})).toBe('http://localhost:3000')
-  expect(safeOrigin('127.0.0.1', {})).toBe('http://localhost:3000')
+  expect(safeOrigin(req('localhost:3001'), { PORT: '3001' })).toBe('http://localhost:3001')
+  expect(safeOrigin(req('localhost:3000'), {})).toBe('http://localhost:3000')
+  expect(safeOrigin(req('127.0.0.1'), {})).toBe('http://localhost:3000')
 })
 
 test('refuses localhost origin when Host is not loopback', () => {
-  expect(safeOrigin('siv-main-sivteam.vercel.app', {})).toMatchObject({
+  expect(safeOrigin(req('siv-main-sivteam.vercel.app'), {})).toMatchObject({
     error: expect.stringMatching(/VERCEL_URL is unset/),
   })
 })

--- a/src/_shared/safeOrigin.ts
+++ b/src/_shared/safeOrigin.ts
@@ -1,3 +1,5 @@
+import type { NextApiRequest } from 'next'
+
 /**
  * Canonical site origin for server-built URLs (emails, unlock fan-out).
  *
@@ -13,7 +15,7 @@
 type OriginEnv = { PORT?: string; VERCEL_URL?: string }
 
 /** Use VERCEL_URL instead of trusting `req.headers.host`, which can be spoofed */
-export function safeOrigin(requestHost?: string, env?: OriginEnv): string | { error: string } {
+export function safeOrigin(req?: NextApiRequest, env?: OriginEnv): string | { error: string } {
   const { PORT, VERCEL_URL } = env ?? process.env
 
   if (VERCEL_URL) {
@@ -24,6 +26,8 @@ export function safeOrigin(requestHost?: string, env?: OriginEnv): string | { er
     return `https://${host}`
   }
 
+  // eslint-disable-next-line siv/no-req-headers-host -- mismatch alarm only; not used as the origin
+  const requestHost = typeof req?.headers?.host === 'string' ? req.headers.host : req?.headers?.host?.[0]
   if (!isLoopbackHost(requestHost)) return { error: `VERCEL_URL is unset but request Host is '${requestHost}'` }
 
   return `http://localhost:${PORT || '3000'}`


### PR DESCRIPTION
## Summary
- Builds login, invite, trustee, receipt, and registration links with `safeOrigin(req)` instead of `req.headers.origin` / `Host`.
- Localhost-only routes gate on `safeOrigin`, so a spoofed `Host: localhost` on Vercel no longer matches.
  - _(they had another check already, but this strengthens this one too)_

Preview this before merging: production emails will use `VERCEL_URL` (may be `*.vercel.app`, not always `siv.org`).

## Test plan
- [ ] **Admin login** — request a login email; link host is this preview (`*-sivteam.vercel.app`), not a forged Origin. Code still works.
- [ ] **Registration confirm** (`submit-link-auth-info`) — “confirm this was me” / invalid links use the preview host; codes still verify.
- [ ] **Voter invite** — invite a voter; ballot `auth=` link is the preview origin and opens the ballot.
- [ ] **Trustee invite** (add + edit email) — observer `auth=` link is the preview origin and opens the protector flow.
- [ ] **Test invitation** — admin test email uses preview origin.
- [ ] **Notify unlocked** — results URL in the email is the preview election page (no secret in URL).
- [ ] **Submit vote** — confirmation email + `visit_to_add_auth` use preview origin; vote still stores.
- [ ] **Admin application** — approval links in the email to you use preview origin.
- [ ] **Unlock** — still fans out / tallies on this preview (system env on).
- [ ] **Localhost** — `reset-test-votes` / `upload-voters-test` still work on `:3000`; on this preview they 405.